### PR TITLE
[FEAT]오늘의 질문 view 구현

### DIFF
--- a/Capple/Capple.xcodeproj/project.pbxproj
+++ b/Capple/Capple.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		07D96EE02B7A1AA600754819 /* AnswerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07D96EDF2B7A1AA600754819 /* AnswerCell.swift */; };
 		07D96EE62B7A52AB00754819 /* FlexView in Frameworks */ = {isa = PBXBuildFile; productRef = 07D96EE52B7A52AB00754819 /* FlexView */; };
 		07D96EE92B7A6D4D00754819 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07D96EE82B7A6D4D00754819 /* View+Extension.swift */; };
+		67B1850C2B9436270057E6BB /* TodayAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B1850B2B9436270057E6BB /* TodayAnswerView.swift */; };
+		67B1850E2B9436450057E6BB /* TodayAnswerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B1850D2B9436450057E6BB /* TodayAnswerViewModel.swift */; };
+		67B185112B9436C10057E6BB /* SingleAnswerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B185102B9436C10057E6BB /* SingleAnswerModel.swift */; };
+		67B185132B9453E30057E6BB /* SingleAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B185122B9453E30057E6BB /* SingleAnswerView.swift */; };
 		82C3790C2B93291C00CC7708 /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790B2B93291C00CC7708 /* ReportView.swift */; };
 		82C3790E2B93292200CC7708 /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790D2B93292200CC7708 /* ReportViewModel.swift */; };
 		82C379102B9330BA00CC7708 /* ReportListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790F2B9330BA00CC7708 /* ReportListRow.swift */; };
@@ -121,6 +125,10 @@
 		07D96EDD2B7A17EF00754819 /* Separator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Separator.swift; sourceTree = "<group>"; };
 		07D96EDF2B7A1AA600754819 /* AnswerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerCell.swift; sourceTree = "<group>"; };
 		07D96EE82B7A6D4D00754819 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
+		67B1850B2B9436270057E6BB /* TodayAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayAnswerView.swift; sourceTree = "<group>"; };
+		67B1850D2B9436450057E6BB /* TodayAnswerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayAnswerViewModel.swift; sourceTree = "<group>"; };
+		67B185102B9436C10057E6BB /* SingleAnswerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleAnswerModel.swift; sourceTree = "<group>"; };
+		67B185122B9453E30057E6BB /* SingleAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleAnswerView.swift; sourceTree = "<group>"; };
 		82C3790B2B93291C00CC7708 /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		82C3790D2B93292200CC7708 /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
 		82C3790F2B9330BA00CC7708 /* ReportListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListRow.swift; sourceTree = "<group>"; };
@@ -333,6 +341,41 @@
 				F3D452D42B8A647F000BA51C /* UINavigationController+Extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		67B185082B9435EF0057E6BB /* TodayAnswersView */ = {
+			isa = PBXGroup;
+			children = (
+				67B1850F2B9436B00057E6BB /* Model */,
+				67B1850A2B9436190057E6BB /* View */,
+				67B185092B9436120057E6BB /* ViewModel */,
+			);
+			path = TodayAnswersView;
+			sourceTree = "<group>";
+		};
+		67B185092B9436120057E6BB /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				67B1850D2B9436450057E6BB /* TodayAnswerViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		67B1850A2B9436190057E6BB /* View */ = {
+			isa = PBXGroup;
+			children = (
+				67B1850B2B9436270057E6BB /* TodayAnswerView.swift */,
+				67B185122B9453E30057E6BB /* SingleAnswerView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		67B1850F2B9436B00057E6BB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				67B185102B9436C10057E6BB /* SingleAnswerModel.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		82C379082B93290700CC7708 /* ReportView */ = {
@@ -620,6 +663,7 @@
 		F3EA67082B76453F002417CE /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				67B185082B9435EF0057E6BB /* TodayAnswersView */,
 				82C379112B9347AB00CC7708 /* AlertView */,
 				82C379082B93290700CC7708 /* ReportView */,
 				F3D452CE2B8A55A5000BA51C /* ProfileEditView */,
@@ -849,12 +893,14 @@
 				F3D452D32B8A6015000BA51C /* CustomNavigationBackButton.swift in Sources */,
 				F37C178C2B873658005E5072 /* MyProfileSummary.swift in Sources */,
 				F392AC472B8B2E370069AD7B /* SignUpCompletedView.swift in Sources */,
+				67B1850E2B9436450057E6BB /* TodayAnswerViewModel.swift in Sources */,
 				07D96EE92B7A6D4D00754819 /* View+Extension.swift in Sources */,
 				82C3790E2B93292200CC7708 /* ReportViewModel.swift in Sources */,
 				F36B0EFA2B86746D009EBE1D /* KeyboardReadable.swift in Sources */,
 				F37C17A72B889999005E5072 /* QuestionViewModel.swift in Sources */,
 				07D96ED82B79E7EB00754819 /* TodayQuestionView.swift in Sources */,
 				07D96EB32B77737500754819 /* Color+Extension.swift in Sources */,
+				67B1850C2B9436270057E6BB /* TodayAnswerView.swift in Sources */,
 				F3EA66F82B764474002417CE /* DummyModel.swift in Sources */,
 				073C3DDA2B870D3B0016C333 /* QuestionTimeManager.swift in Sources */,
 				F3D452D72B8A663E000BA51C /* CustomNavigationTextButton.swift in Sources */,
@@ -866,6 +912,7 @@
 				F3EA67062B76450F002417CE /* BaseRequest.swift in Sources */,
 				07D96ED12B7797CD00754819 /* Font+Extension.swift in Sources */,
 				07BF36362B8B36D10047F3F7 /* AnswerViewModel.swift in Sources */,
+				67B185112B9436C10057E6BB /* SingleAnswerModel.swift in Sources */,
 				07D96EE02B7A1AA600754819 /* AnswerCell.swift in Sources */,
 				82C3791B2B93499300CC7708 /* Alert.swift in Sources */,
 				F3EA66CE2B7643EE002417CE /* HomeView.swift in Sources */,
@@ -877,6 +924,7 @@
 				07D96EDC2B7A167200754819 /* SeeAllButton.swift in Sources */,
 				82C379172B9347F400CC7708 /* AlertViewModel.swift in Sources */,
 				82C379192B93483B00CC7708 /* AlertListRow.swift in Sources */,
+				67B185132B9453E30057E6BB /* SingleAnswerView.swift in Sources */,
 				F37C179F2B88977E005E5072 /* Question.swift in Sources */,
 				F3EA66FD2B7644D0002417CE /* ApiEnpoints.swift in Sources */,
 				F3EA66CC2B7643EE002417CE /* CappleApp.swift in Sources */,

--- a/Capple/Capple/App/CappleApp.swift
+++ b/Capple/Capple/App/CappleApp.swift
@@ -16,7 +16,7 @@ struct CappleApp: App {
     
     var body: some Scene {
         WindowGroup {
-            SearchResultView()
+            TodayAnswerView()
         }
     }
     

--- a/Capple/Capple/Presentation/TodayAnswersView/Model/SingleAnswerModel.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/Model/SingleAnswerModel.swift
@@ -1,0 +1,17 @@
+//
+//  TodayAnswerModel.swift
+//  Capple
+//
+//  Created by ShimHyeonhee on 3/3/24.
+//
+
+import Foundation
+struct SingleAnswer: Identifiable {
+    var id: Int
+    var name: String
+    var content: String
+    var tags: [String]
+    var likes: Int
+    // 여기에 더 많은 필드를 추가할 수 있습니다.
+}
+

--- a/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
@@ -1,0 +1,62 @@
+//
+//  Answer.swift
+//  Capple
+//
+//  Created by ShimHyeonhee on 3/3/24.
+//
+
+import Foundation
+import SwiftUI
+
+// 하나의 질문을 보여주는 뷰를 정의합니다.
+struct SingleAnswerView: View {
+    var answer: SingleAnswer // 이 뷰에서 사용할 질문 객체입니다.
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) { // 세로 스택을 사용해 요소들을 정렬합니다.
+            
+            HStack { // 이름과 이미지를 가로로 배열하기 위한 HStack 추가
+                            Image(systemName: "person.crop.circle.fill") // 여기서 "avatar"는 예시 이미지 이름입니다. 적절한 이미지 이름으로 교체해야 합니다.
+                                .resizable() // 이미지의 크기를 조절할 수 있도록 설정합니다.
+                                .aspectRatio(contentMode: .fill) // 이미지의 비율을 유지하며 채웁니다.
+                                .frame(width: 50, height: 50) // 이미지의 크기를 설정합니다.
+                                .clipShape(Circle()) // 이미지를 원형으로 자릅니다.
+                                .padding(.trailing, 10) // 이미지와 이름 사이의 간격을 설정합니다.
+                            
+                            Text(answer.name) // 질문의 제목을 표시합니다.
+                                .foregroundColor(.white) // 글자 색상을 흰색으로 설정합니다.
+                                .font(.title3) // 글자 크기를 설정합니다.
+                                .fontWeight(.bold) // 글자 두께를 굵게 설정합니다.
+                        }
+            
+            Text("\(answer.likes) likes") // 좋아요 수와 댓글 수를 표시합니다.
+                .foregroundColor(.gray) // 글자 색상을 회색으로 설정합니다.
+                .font(.caption) // 작은 글자 크기로 설정합니다.
+            
+            Divider().background(Color.gray) // 구분선을 추가합니다.
+            
+            
+            
+            HStack { // 가로 스택을 사용해 태그를 나열합니다.
+                ForEach(answer.tags, id: \.self) { tag in
+                    Text("#\(tag)") // 각 태그를 표시합니다.
+                        .foregroundColor(.blue) // 글자 색상을 파란색으로 설정합니다.
+                        .font(.caption) // 작은 글자 크기로 설정합니다.
+                }
+            }
+            
+            HStack { // 좋아요와 댓글 아이콘을 가로로 나열합니다.
+                Image(systemName: "heart.fill") // 좋아요 아이콘을 표시합니다.
+                    .foregroundColor(.red) // 아이콘 색상을 빨간색으로 설정합니다.
+                Text("\(answer.likes)") // 좋아요 수를 표시합니다.
+                    .foregroundColor(.white) // 글자 색상을 흰색으로 설정합니다.
+                    .font(.subheadline) // 약간 작은 글자 크기로 설정합니다.
+            }
+        }
+        .padding() // 내부 요소와의 간격을 설정합니다.
+        .background(Color.gray.opacity(0.2)) // 배경색을 설정하고 투명도를 조절합니다.
+        .cornerRadius(10) // 모서리를 둥글게 처리합니다.
+        .padding(.horizontal) // 좌우 간격을 설정합니다.
+    }
+}
+

--- a/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
@@ -29,7 +29,11 @@ struct SingleAnswerView: View {
                                 .fontWeight(.bold) // 글자 두께를 굵게 설정합니다.
                         }
             
-            Text("\(answer.likes) likes") // 좋아요 수와 댓글 수를 표시합니다.
+            Text("\(answer.content) This is Description and contents") // 좋아요 수
+                .foregroundColor(.gray) // 글자 색상을 회색으로 설정합니다.
+                .font(.caption) // 작은 글자 크기로 설정
+            
+            Text("\(answer.likes) likes") // 좋아요 수
                 .foregroundColor(.gray) // 글자 색상을 회색으로 설정합니다.
                 .font(.caption) // 작은 글자 크기로 설정합니다.
             

--- a/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
@@ -1,0 +1,153 @@
+//
+//  TodayAnswer.swift
+//  Capple
+//
+//  Created by ShimHyeonhee on 3/3/24.
+//
+
+import Foundation
+import SwiftUI
+
+
+struct TodayAnswerView: View {
+    @ObservedObject var viewModel = TodayAnswersViewModel()
+    let cardHeight: CGFloat = 150 // 답변 카드의 높이를 정의합니다.
+    @State private var isCardExpanded: Bool = true // 플로팅 카드 확장/축소 상태 관리를 위한 상태 변수 추가
+        
+
+    var body: some View {
+        NavigationView {
+            
+            VStack(alignment: .leading) {
+                // 키워드 스크롤 뷰
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(viewModel.keywords, id: \.self) { keyword in
+                            Text(keyword)
+                                .font(.system(size: 14, weight: .medium))
+                                .padding(.vertical, 8)
+                                .padding(.horizontal, 16)
+                                .background(Color.Background.second)
+                                .cornerRadius(20)
+                                .foregroundColor(.white)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+                
+                // 플로팅 질문 카드
+                if isCardExpanded { // 카드가 확장되어 있는 경우에만 내용을 보여줍니다.
+                                    HStack {
+                                        Image(systemName: "q.circle.fill") // Q 아이콘 추가
+                                            .foregroundColor(.white)
+                                            .padding(.leading, 5)
+                                        
+                                        Text(viewModel.todayQuestion)
+                                            .font(.system(size: 17, weight: .regular))
+                                            .foregroundColor(.white)
+                                        
+                                        Spacer() // 화살표를 오른쪽으로 밀어내기 위해 Spacer 추가
+                                        
+                                        Button(action: {
+                                            withAnimation {
+                                                isCardExpanded.toggle() // 버튼 클릭 시 카드 확장/축소 상태 토글
+                                            }
+                                        }) {
+                                            Image(systemName: "chevron.up") // 위쪽 화살표 아이콘 추가
+                                                .foregroundColor(.white)
+                                        }
+                                        .padding(.trailing, 5)
+                                    }
+                                    .padding()
+                                    .frame(maxWidth: .infinity)
+                                    .background(Color.Background.second)
+                                    .cornerRadius(15)
+                                    .shadow(color: .gray.opacity(0.5), radius: 4, x: 0, y: 4)
+                                    .padding(.horizontal)
+                                    .padding(.top, 20)
+                                } else { // 카드가 축소되어 있는 경우, 확장 버튼만 보여줍니다.
+                                    Button(action: {
+                                        withAnimation {
+                                            isCardExpanded.toggle() // 버튼 클릭 시 카드 확장/축소 상태 토글
+                                        }
+                                    }) {
+                                        Image(systemName: "chevron.down") // 아래쪽 화살표 아이콘으로 변경
+                                            .foregroundColor(.white)
+                                            .padding()
+                                            .background(Color.Background.second)
+                                            .cornerRadius(15)
+                                            .shadow(color: .gray.opacity(0.5), radius: 4, x: 0, y: 4)
+                                            .frame(maxWidth: .infinity, alignment: .trailing)
+                                            .padding(.horizontal)
+                                    }
+                                }
+                
+                // 답변들을 표시하는 스크롤 뷰
+                ScrollView(.vertical, showsIndicators: false) {
+                    LazyVStack {
+                        /*
+                            ForEach(viewModel.filteredAnswer) { answer in
+                                SingleAnswerView(answer: answer) // 각 질문에 대한 뷰를 생성합니다.
+                                    .onAppear {
+                                        viewModel.loadMoreContentIfNeeded(currentItem: answer) // 필요한 경우 더 많은 내용을 로드합니다.
+                                    }
+                                    .padding(.vertical, 8) // 질문 사이의 수직 패딩을 추가합니다.
+                                    .background(Color.black) // 각 질문의 배경색을 검정색으로 설정합니다.
+                            }
+                            if viewModel.isLoading { // 로딩 중인 경우 로딩 인디케이터를 표시합니다.
+                                ProgressView()
+                                    .scaleEffect(1.5)
+                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                            }
+                        */
+                        
+                        ForEach(viewModel.answers.indices, id: \.self) {
+                            index in
+                            GeometryReader { geometry in
+                               
+                                let frame = geometry.frame(in: .global)
+                                let midY = frame.midY
+                                let midX = frame.midX
+                                let screenHeight = UIScreen.main.bounds.height
+                                let scale = min(1.0, 1 - abs(midY - screenHeight / 2) / midX)
+                                
+                                SingleAnswerView(answer: viewModel.filteredAnswer[index])
+                                    .frame(width: geometry.size.width)
+                                    .frame(height: self.cardHeight)
+                                    .padding()
+                                    .background(Color.Background.second)
+                                    .opacity(1)
+                                    .cornerRadius(10)
+                                    .shadow(color: .gray.opacity(0.5), radius: 4, x: 0, y: 2)
+                                    .scaleEffect(scale) // 현재 보이는 카드를 기준으로 크기 조정
+                                    .opacity(scale) // 중앙에 위치할수록 더 뚜렷하게 보이도록 설정
+                                    .onAppear {
+                                        if index == viewModel.answers.count - 1 { // 마지막 항목에 도달하면 더 많은 데이터 로드
+                                            viewModel.loadMoreAnswers()
+                                        }
+                                    }
+                            }
+                            .frame(height: self.cardHeight) // GeometryReader에도 높이 설정
+                        }
+                        
+                    }
+                }
+            }
+            .navigationBarTitle("오늘의 질문", displayMode: .inline)
+            .navigationBarItems(leading: Button(action: {}) {
+                Image(systemName: "arrow.left")
+                    .foregroundColor(.white)
+            }, trailing: Button(action: {}) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.white)
+            })
+            .background(Color.Background.first)
+        }
+    }
+}
+
+struct TodayAnswerView_Previews: PreviewProvider {
+    static var previews: some View {
+        TodayAnswerView()
+    }
+}

--- a/Capple/Capple/Presentation/TodayAnswersView/ViewModel/TodayAnswerViewModel.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/ViewModel/TodayAnswerViewModel.swift
@@ -1,0 +1,101 @@
+
+//
+//  TodayAnswer.swift
+//  Capple
+//
+//  Created by ShimHyeonhee on 3/3/24.
+//
+
+import Foundation
+
+/*
+class TodayAnswerViewModel: ObservableObject {
+    @Published var posts: [Post] = []
+    
+    // 데이터를 로드하는 메소드
+    func loadPosts() {
+        // 여기서 실제 데이터를 로드하는 로직을 구현합니다.
+        // 예제를 위해 임시 데이터를 생성합니다.
+        posts = [
+            Post(title: "첫 번째 포스트", content: "첫 번째 포스트의 내용입니다.", likes: 32),
+            // 더 많은 포스트를 추가할 수 있습니다.
+        ]
+    }
+}
+*/
+/*
+// 뷰모델은 UI에 표시될 데이터와 로직을 관리합니다.
+class TodayAnswersViewModel: ObservableObject {
+    // 키워드 배열을 관리하는 프로퍼티입니다. 실제 앱에서는 서버나 데이터베이스에서 가져올 수 있습니다.
+    @Published var keywords: [String] = ["ALL", "쌀국수", "와플", "물", "아무고토"]
+    
+    // 오늘의 질문을 관리하는 프로퍼티입니다. 이것도 실제 앱에서는 변경될 수 있습니다.
+    @Published var todayQuestion: String = "가장 최근에 먹었던 음식 중 가장 인상깊었던 것은 무엇인가요?"
+    
+    // 질문에 대한 답변들을 관리하는 프로퍼티입니다. 실제 앱에서는 사용자의 입력을 받아 업데이트 될 수 있습니다.
+    @Published var answers: [String] = ["답변 1", "답변 2", "답변 3"] // 예시 답변입니다.
+    
+    // 초기화 함수입니다. 필요한 데이터를 불러오는 등의 초기 작업을 수행할 수 있습니다.
+    init() {
+        // 데이터 로딩 로직을 여기에 추가할 수 있습니다.
+    }
+}
+*/
+import Foundation
+
+class TodayAnswersViewModel: ObservableObject {
+    @Published var keywords: [String] = ["ALL", "쌀국수", "와플", "물", "아무고토", "없어요", "샐러드", "처갓집양념치킨"]
+    @Published var todayQuestion: String = "가장 최근에 먹었던 음식 중 가장 인상깊었던 것은 무엇인가요?"
+    @Published var answers: [SingleAnswer] = []
+    @Published var filteredAnswer: [SingleAnswer] = [] // 검색 쿼리에 따라 필터링된 질문 목록입니다.
+    @Published var searchQuery = ""
+    @Published var isLoading = false // 데이터 로딩 중인지 여부를 나타냅니다.
+    
+    
+    private var currentPage = 0 // 현재 로드된 페이지 번호입니다.
+    private let pageSize = 15 // 한 번에 로드할 데이터의 양입니다.
+    
+    init() {
+        loadMoreAnswers() // 초기 데이터 로딩
+
+    }
+    
+    func loadMoreAnswers() {
+        // 여기서 더 많은 답변들을 로드하는 로직을 구현합니다.
+        // 예시로, 기존 답변들을 복사하여 추가합니다.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            guard let self = self else { return }
+            
+            let newAnswers = (1...10).map { i in
+                SingleAnswer(id: self.currentPage * self.pageSize + i, name: "Name \((self.currentPage * self.pageSize) + i)", content: "Description Answer \(i) is This", tags: ["Tag\(i)", "Tag\(i * 2)"], likes: i * 2 )
+            }
+            self.answers.append(contentsOf: newAnswers )
+            self.filterQuestions(with: searchQuery)
+            self.isLoading = false
+            self.currentPage += 1
+        }
+    }
+    func loadMoreContentIfNeeded(currentItem item: SingleAnswer?) {
+        guard let item = item, !isLoading else { return }
+        
+        let thresholdIndex = answers.index(answers.endIndex, offsetBy: -5)
+        if let itemIndex = answers.firstIndex(where: { $0.id == item.id }), itemIndex >= thresholdIndex {
+            loadMoreAnswers()
+        }
+    }
+    func filterQuestions(with searchText : String) {
+        print("\(searchText)")
+        if searchText.isEmpty {
+            filteredAnswer =  self.answers
+
+        } else {
+            filteredAnswer = self.answers.filter { answer in
+                answer.name.localizedCaseInsensitiveContains(searchText) ||
+                answer.tags.contains(where: { $0.localizedCaseInsensitiveContains(searchText) })
+            }
+        }
+
+
+    }
+}
+


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정

## 반영 브랜치
feature/#31/TodayAnswerView -> develop

## 변경 사항
오늘의 질문 뷰를 구현했습니다. 
질문 플로팅 카드를 접었다 펼수 있습니다. 
키워드 좌우 스크롤링 되어 있습니다. 
필터링 기능은 구현만 되어있고 아직 돋보기 아이콘과 연결되어있지 않습니다. 
스크롤에 따른 답변 하이라이트 기능을 구현했습니다. 

## 테스트 결과
<img width="308" alt="스크린샷 2024-03-03 오후 6 24 21" src="https://github.com/Team-Capple/Capple-iOS/assets/97822063/e6b51fd5-55e0-4a26-83eb-97e002992fdf">
<img width="300" alt="스크린샷 2024-03-03 오후 6 24 29" src="https://github.com/Team-Capple/Capple-iOS/assets/97822063/6930aa51-dd34-4987-81c3-40cdae4699ec">

