### PR TITLE
[FEAT] 태그(키워드) API 연결

### DIFF
--- a/Capple/Capple.xcodeproj/project.pbxproj
+++ b/Capple/Capple.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		67B185132B9453E30057E6BB /* SingleAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B185122B9453E30057E6BB /* SingleAnswerView.swift */; };
 		67F102952B994B0300DA17A4 /* QuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F102942B994B0300DA17A4 /* QuestionModel.swift */; };
 		82398F092B98ABB4006269E0 /* DTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82398F082B98ABB4006269E0 /* DTO.swift */; };
+		828715BC2B99F6EA001627DB /* TagRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BB2B99F6EA001627DB /* TagRequest.swift */; };
 		82C3790C2B93291C00CC7708 /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790B2B93291C00CC7708 /* ReportView.swift */; };
 		82C3790E2B93292200CC7708 /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790D2B93292200CC7708 /* ReportViewModel.swift */; };
 		82C379102B9330BA00CC7708 /* ReportListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790F2B9330BA00CC7708 /* ReportListRow.swift */; };
@@ -139,6 +140,7 @@
 		67B185122B9453E30057E6BB /* SingleAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleAnswerView.swift; sourceTree = "<group>"; };
 		67F102942B994B0300DA17A4 /* QuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionModel.swift; sourceTree = "<group>"; };
 		82398F082B98ABB4006269E0 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
+		828715BB2B99F6EA001627DB /* TagRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagRequest.swift; sourceTree = "<group>"; };
 		82C3790B2B93291C00CC7708 /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		82C3790D2B93292200CC7708 /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
 		82C3790F2B9330BA00CC7708 /* ReportListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListRow.swift; sourceTree = "<group>"; };
@@ -679,6 +681,7 @@
 			isa = PBXGroup;
 			children = (
 				F3EA67052B76450F002417CE /* BaseRequest.swift */,
+				828715BB2B99F6EA001627DB /* TagRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -956,6 +959,7 @@
 				07BF364A2B8B9C420047F3F7 /* SearchKeywordView.swift in Sources */,
 				82D583BB2B985462003CC424 /* NetworkManager.swift in Sources */,
 				07BF363F2B8B82C90047F3F7 /* ConfirmAnswerView.swift in Sources */,
+				828715BC2B99F6EA001627DB /* TagRequest.swift in Sources */,
 				82D583B92B9852C4003CC424 /* QuestionResponse.swift in Sources */,
 				073C3DDE2B8714240016C333 /* QuestionTimeZone.swift in Sources */,
 				07D96EDC2B7A167200754819 /* SeeAllButton.swift in Sources */,

--- a/Capple/Capple.xcodeproj/project.pbxproj
+++ b/Capple/Capple.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		67F102952B994B0300DA17A4 /* QuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F102942B994B0300DA17A4 /* QuestionModel.swift */; };
 		82398F092B98ABB4006269E0 /* DTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82398F082B98ABB4006269E0 /* DTO.swift */; };
 		828715BC2B99F6EA001627DB /* TagRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BB2B99F6EA001627DB /* TagRequest.swift */; };
+		828715BE2B99FC54001627DB /* TagResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BD2B99FC54001627DB /* TagResponse.swift */; };
 		82C3790C2B93291C00CC7708 /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790B2B93291C00CC7708 /* ReportView.swift */; };
 		82C3790E2B93292200CC7708 /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790D2B93292200CC7708 /* ReportViewModel.swift */; };
 		82C379102B9330BA00CC7708 /* ReportListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C3790F2B9330BA00CC7708 /* ReportListRow.swift */; };
@@ -141,6 +142,7 @@
 		67F102942B994B0300DA17A4 /* QuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionModel.swift; sourceTree = "<group>"; };
 		82398F082B98ABB4006269E0 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
 		828715BB2B99F6EA001627DB /* TagRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagRequest.swift; sourceTree = "<group>"; };
+		828715BD2B99FC54001627DB /* TagResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagResponse.swift; sourceTree = "<group>"; };
 		82C3790B2B93291C00CC7708 /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		82C3790D2B93292200CC7708 /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
 		82C3790F2B9330BA00CC7708 /* ReportListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListRow.swift; sourceTree = "<group>"; };
@@ -673,6 +675,7 @@
 			children = (
 				F3EA67022B764504002417CE /* BaseResponse.swift */,
 				82D583B82B9852C4003CC424 /* QuestionResponse.swift */,
+				828715BD2B99FC54001627DB /* TagResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -937,6 +940,7 @@
 				07D96ED82B79E7EB00754819 /* TodayQuestionView.swift in Sources */,
 				07D96EB32B77737500754819 /* Color+Extension.swift in Sources */,
 				67B1850C2B9436270057E6BB /* TodayAnswerView.swift in Sources */,
+				828715BE2B99FC54001627DB /* TagResponse.swift in Sources */,
 				F3EA66F82B764474002417CE /* DummyModel.swift in Sources */,
 				073C3DDA2B870D3B0016C333 /* QuestionTimeManager.swift in Sources */,
 				F3D452D72B8A663E000BA51C /* CustomNavigationTextButton.swift in Sources */,

--- a/Capple/Capple/Data/Network/ApiEndpoints.swift
+++ b/Capple/Capple/Data/Network/ApiEndpoints.swift
@@ -15,6 +15,7 @@ enum ApiEndpoints {
     enum Path: String {
         case questions = "/questions"
         case tagSearch = "/tags/search?"
+        case popularTagsInQuestion = "/tags"
     }
 }
 

--- a/Capple/Capple/Data/Network/ApiEndpoints.swift
+++ b/Capple/Capple/Data/Network/ApiEndpoints.swift
@@ -14,14 +14,14 @@ enum ApiEndpoints {
     
     enum Path: String {
         case questions = "/questions"
+        case tagSearch = "/tags/search?"
     }
 }
 
 extension ApiEndpoints {
     
     /// 기본 URL 주소 문자열을 반환합니다.
-    static func basicURLString(path: ApiEndpoints.Path) -> URL? {
-        let url = URL(string: "\(scheme)://\(host):\(port)\(path.rawValue)")
-        return url
+    static func basicURLString(path: ApiEndpoints.Path) -> String {
+        return "\(scheme)://\(host):\(port)\(path.rawValue)"
     }
 }

--- a/Capple/Capple/Data/Network/DataMapping/Request/TagRequest.swift
+++ b/Capple/Capple/Data/Network/DataMapping/Request/TagRequest.swift
@@ -9,8 +9,13 @@ import Foundation
 
 class TagRequest {
     
-    // 태그(키워드) 검색 구조체
+    /// 태그(키워드) 검색 구조체
     struct Search {
         let keyword: String // 검색할 태그(키워드)
+    }
+    
+    /// 질문에 많이 사용된 태그(키워드) 조회 구조체
+    struct PopularTagsInQuestion {
+        let questionId: Int // 질문 아이디
     }
 }

--- a/Capple/Capple/Data/Network/DataMapping/Request/TagRequest.swift
+++ b/Capple/Capple/Data/Network/DataMapping/Request/TagRequest.swift
@@ -1,0 +1,16 @@
+//
+//  TagRequest.swift
+//  Capple
+//
+//  Created by 김민준 on 3/7/24.
+//
+
+import Foundation
+
+class TagRequest {
+    
+    // 태그(키워드) 검색 구조체
+    struct Search {
+        let keyword: String // 검색할 태그(키워드)
+    }
+}

--- a/Capple/Capple/Data/Network/DataMapping/Response/TagResponse.swift
+++ b/Capple/Capple/Data/Network/DataMapping/Response/TagResponse.swift
@@ -1,0 +1,16 @@
+//
+//  TagResponse.swift
+//  Capple
+//
+//  Created by 김민준 on 3/7/24.
+//
+
+import Foundation
+
+struct TagResponse {
+    
+    /// 태그(키워드) 검색 Response
+    struct Search: Codable {
+        let tags: [String]
+    }
+}

--- a/Capple/Capple/Data/Network/DataMapping/Response/TagResponse.swift
+++ b/Capple/Capple/Data/Network/DataMapping/Response/TagResponse.swift
@@ -13,4 +13,9 @@ struct TagResponse {
     struct Search: Codable {
         let tags: [String]
     }
+    
+    /// 질문에 많이 사용된 태그(키워드) 조회 Response
+    struct PopularTagsInQuestion: Codable {
+        let tags: [String]
+    }
 }

--- a/Capple/Capple/Data/Network/NetworkManager.swift
+++ b/Capple/Capple/Data/Network/NetworkManager.swift
@@ -9,11 +9,17 @@ import Foundation
 
 class NetworkManager: ObservableObject {
     
+}
+
+// MARK: - 질문 API
+extension NetworkManager {
+    
     /// 오늘의 메인 질문을 조회합니다.
     static func fetchMainQuestions() async throws -> QuestionResponse.MainQuestions {
         
         // URL 객체 생성
-        guard let url = ApiEndpoints.basicURLString(path: .questions) else {
+        let urlString = ApiEndpoints.basicURLString(path: .questions)
+        guard let url = URL(string: urlString) else {
             print("Error: cannotCreateURL")
             throw NetworkError.cannotCreateURL
         }
@@ -36,3 +42,36 @@ class NetworkManager: ObservableObject {
         return decodeData.result
     }
 }
+
+// MARK: - 태그(키워드) API
+extension NetworkManager {
+    
+    /// 검색한 태그(키워드)를 조회합니다.
+    static func fetchSearchTag(request: TagRequest.Search) async throws -> TagResponse.Search {
+        
+        // URL 객체 생성
+        let urlString = ApiEndpoints.basicURLString(path: .tagSearch) + "keyword=\(request.keyword)"
+        guard let url = URL(string: urlString) else {
+            print("Error: cannotCreateURL")
+            throw NetworkError.cannotCreateURL
+        }
+        
+        // URLSession 생성
+        let (data, response) = try await URLSession.shared.data(from: url)
+        print(data)
+        print(response)
+        
+        // 에러 체크
+        if let response = response as? HTTPURLResponse,
+           !(200..<300).contains(response.statusCode) {
+            print("Error: badRequest")
+            throw NetworkError.badRequest
+        }
+        
+        // 디코딩
+        let decoder = JSONDecoder()
+        let decodeData = try decoder.decode(BaseResponse<TagResponse.Search>.self, from: data)
+        return decodeData.result
+    }
+}
+

--- a/Capple/Capple/Data/Network/NetworkManager.swift
+++ b/Capple/Capple/Data/Network/NetworkManager.swift
@@ -73,5 +73,33 @@ extension NetworkManager {
         let decodeData = try decoder.decode(BaseResponse<TagResponse.Search>.self, from: data)
         return decodeData.result
     }
+    
+    /// 질문에 많이 사용된 태그(키워드)를 조회합니다.
+    static func fetchPopularTagsInQuestion(request: TagRequest.PopularTagsInQuestion) async throws -> TagResponse.PopularTagsInQuestion {
+        
+        // URL 객체 생성
+        let urlString = ApiEndpoints.basicURLString(path: .popularTagsInQuestion) + "/\(request.questionId)"
+        guard let url = URL(string: urlString) else {
+            print("Error: cannotCreateURL")
+            throw NetworkError.cannotCreateURL
+        }
+        
+        // URLSession 생성
+        let (data, response) = try await URLSession.shared.data(from: url)
+        print(data)
+        print(response)
+        
+        // 에러 체크
+        if let response = response as? HTTPURLResponse,
+           !(200..<300).contains(response.statusCode) {
+            print("Error: badRequest")
+            throw NetworkError.badRequest
+        }
+        
+        // 디코딩
+        let decoder = JSONDecoder()
+        let decodeData = try decoder.decode(BaseResponse<TagResponse.PopularTagsInQuestion>.self, from: data)
+        return decodeData.result
+    }
 }
 

--- a/Capple/Capple/Presentation/HomeView/View/HomeView.swift
+++ b/Capple/Capple/Presentation/HomeView/View/HomeView.swift
@@ -16,9 +16,13 @@ struct HomeView: View {
         case .answering:
             TodayQuestionView(topTab: $topTab)
                 .onAppear {
+                    
+                    // TODO: 테스트용 코드
                     Task {
                         let tagSearch = try await NetworkManager.fetchSearchTag(request: .init(keyword: "키워드"))
+                        let popularTag = try await NetworkManager.fetchPopularTagsInQuestion(request: .init(questionId: 1))
                         print(tagSearch)
+                        print(popularTag)
                     }
                 }
         case .collecting:

--- a/Capple/Capple/Presentation/HomeView/View/HomeView.swift
+++ b/Capple/Capple/Presentation/HomeView/View/HomeView.swift
@@ -15,6 +15,12 @@ struct HomeView: View {
         switch topTab {
         case .answering:
             TodayQuestionView(topTab: $topTab)
+                .onAppear {
+                    Task {
+                        let tagSearch = try await NetworkManager.fetchSearchTag(request: .init(keyword: "키워드"))
+                        print(tagSearch)
+                    }
+                }
         case .collecting:
             SearchResultView(topTab: $topTab)
         }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정

## 반영 브랜치
ex) feature/#42/KeywordAPI -> develop

## 변경 사항
- TagRequest, TagResponse 구조체를 추가했습니다.
- ApiEndPoints의 extension 메서드인 basicURLString의 반환 타입을 URL? 에서 String으로 변경했습니다. (파라미터 붙이기 쉽게)
- 태그 검색, 질문에서 많이 사용된 키워드 조회 네트워킹 메서드 구현 및 테스트를 완료했습니다.

## 코멘트
- View와 연결 작업은 추후 한번에 진행 예정입니다.
- 네트워킹 반복 코드(ex: status 코드, decoder 생성 등등...) 리팩토링 작업은 1차 배포 완료 후 진행해봐요!

## 테스트 결과
![image](https://github.com/Team-Capple/Capple-iOS/assets/113565086/98b32683-739e-4cfa-a079-95941bb473c5)
