### PR TITLE
[FEAT] API 연결 및 마이페이지 뷰 업데이트

### DIFF
--- a/Capple/Capple.xcodeproj/project.pbxproj
+++ b/Capple/Capple.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		82398F092B98ABB4006269E0 /* DTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82398F082B98ABB4006269E0 /* DTO.swift */; };
 		825226E82BA6E529006998E8 /* SignInInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825226E72BA6E529006998E8 /* SignInInfo.swift */; };
 		825226EA2BA857FF006998E8 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825226E92BA857FF006998E8 /* String+Extension.swift */; };
+		825226ED2BA96CEF006998E8 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825226EC2BA96CEF006998E8 /* MyPageViewModel.swift */; };
 		828715BC2B99F6EA001627DB /* TagRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BB2B99F6EA001627DB /* TagRequest.swift */; };
 		828715BE2B99FC54001627DB /* TagResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BD2B99FC54001627DB /* TagResponse.swift */; };
 		828715C02B9AC866001627DB /* AnswerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BF2B9AC866001627DB /* AnswerRequest.swift */; };
@@ -163,6 +164,7 @@
 		82398F082B98ABB4006269E0 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
 		825226E72BA6E529006998E8 /* SignInInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInInfo.swift; sourceTree = "<group>"; };
 		825226E92BA857FF006998E8 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		825226EC2BA96CEF006998E8 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		828715BB2B99F6EA001627DB /* TagRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagRequest.swift; sourceTree = "<group>"; };
 		828715BD2B99FC54001627DB /* TagResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagResponse.swift; sourceTree = "<group>"; };
 		828715BF2B9AC866001627DB /* AnswerRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerRequest.swift; sourceTree = "<group>"; };
@@ -449,6 +451,14 @@
 			name = NetworklManager;
 			sourceTree = "<group>";
 		};
+		825226EB2BA96CE6006998E8 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				825226EC2BA96CEF006998E8 /* MyPageViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		8295BDBB2BA3303700115FA8 /* Key */ = {
 			isa = PBXGroup;
 			children = (
@@ -570,6 +580,7 @@
 		F37C17872B873419005E5072 /* MyPageView */ = {
 			isa = PBXGroup;
 			children = (
+				825226EB2BA96CE6006998E8 /* ViewModel */,
 				F37C17882B873425005E5072 /* View */,
 			);
 			path = MyPageView;
@@ -1032,6 +1043,7 @@
 				07D96EDC2B7A167200754819 /* SeeAllButton.swift in Sources */,
 				82C379172B9347F400CC7708 /* AlertViewModel.swift in Sources */,
 				82C3791D2B943CDB00CC7708 /* Date+Extension.swift in Sources */,
+				825226ED2BA96CEF006998E8 /* MyPageViewModel.swift in Sources */,
 				82C379192B93483B00CC7708 /* AlertListRow.swift in Sources */,
 				82D583B72B9844E6003CC424 /* KeywordSelector.swift in Sources */,
 				67B185132B9453E30057E6BB /* SingleAnswerView.swift in Sources */,

--- a/Capple/Capple.xcodeproj/project.pbxproj
+++ b/Capple/Capple.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		825226E82BA6E529006998E8 /* SignInInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825226E72BA6E529006998E8 /* SignInInfo.swift */; };
 		825226EA2BA857FF006998E8 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825226E92BA857FF006998E8 /* String+Extension.swift */; };
 		825226ED2BA96CEF006998E8 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825226EC2BA96CEF006998E8 /* MyPageViewModel.swift */; };
+		825226EF2BA9A7D8006998E8 /* MailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825226EE2BA9A7D8006998E8 /* MailView.swift */; };
 		828715BC2B99F6EA001627DB /* TagRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BB2B99F6EA001627DB /* TagRequest.swift */; };
 		828715BE2B99FC54001627DB /* TagResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BD2B99FC54001627DB /* TagResponse.swift */; };
 		828715C02B9AC866001627DB /* AnswerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828715BF2B9AC866001627DB /* AnswerRequest.swift */; };
@@ -165,6 +166,7 @@
 		825226E72BA6E529006998E8 /* SignInInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInInfo.swift; sourceTree = "<group>"; };
 		825226E92BA857FF006998E8 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		825226EC2BA96CEF006998E8 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
+		825226EE2BA9A7D8006998E8 /* MailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailView.swift; sourceTree = "<group>"; };
 		828715BB2B99F6EA001627DB /* TagRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagRequest.swift; sourceTree = "<group>"; };
 		828715BD2B99FC54001627DB /* TagResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagResponse.swift; sourceTree = "<group>"; };
 		828715BF2B9AC866001627DB /* AnswerRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerRequest.swift; sourceTree = "<group>"; };
@@ -826,6 +828,7 @@
 				82C3791E2B94A50000CC7708 /* Tab.swift */,
 				828715C72B9BFB9E001627DB /* MainPathModel.swift */,
 				8295BDAF2BA31C5C00115FA8 /* PrivacyDocument.swift */,
+				825226EE2BA9A7D8006998E8 /* MailView.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -987,6 +990,7 @@
 				F36F37C82B9B7A54002EC36B /* AuthViewModel.swift in Sources */,
 				07BF36482B8B9C290047F3F7 /* SearchKeywordViewModel.swift in Sources */,
 				07BF36412B8B86310047F3F7 /* KeywordChoiceChip.swift in Sources */,
+				825226EF2BA9A7D8006998E8 /* MailView.swift in Sources */,
 				F392AC452B8B2E370069AD7B /* SignUpNicknameView.swift in Sources */,
 				8295BDB82BA322E600115FA8 /* NetworkManager+Tag.swift in Sources */,
 				07D96EDE2B7A17EF00754819 /* Separator.swift in Sources */,

--- a/Capple/Capple/Data/Network/DataMapping/ApiEndpoints.swift
+++ b/Capple/Capple/Data/Network/DataMapping/ApiEndpoints.swift
@@ -28,6 +28,7 @@ enum ApiEndpoints {
         // MARK: - 멤버
         case signIn = "/members/sign-in"
         case signUp = "/members/sign-up"
+        case myPage = "/members/mypage"
     }
 }
 

--- a/Capple/Capple/Data/Network/DataMapping/Response/MemberResponse.swift
+++ b/Capple/Capple/Data/Network/DataMapping/Response/MemberResponse.swift
@@ -19,4 +19,10 @@ struct MemberResponse {
         let accessToken: String?
         let refreshToken: String?
     }
+    
+    struct MyPage: Codable {
+        let nickname: String
+        let profileImage: String?
+        let joinDate: String
+    }
 }

--- a/Capple/Capple/Data/Network/NetworkManager+Member.swift
+++ b/Capple/Capple/Data/Network/NetworkManager+Member.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// MARK: - 멤버 관련 API
+// MARK: - 로그인 및 회원가입 Member
 extension NetworkManager {
     
     /// 로그인 요청을 합니다.
@@ -87,5 +87,42 @@ extension NetworkManager {
         } catch {
             throw NetworkError.decodeFailed
         }
+    }
+}
+
+// MARK: - 마이페이지 조회
+extension NetworkManager {
+    
+    /// 마이페이지 정보를 요청합니다.
+    static func requestMyPage() async throws -> MemberResponse.MyPage {
+        
+        // URL 객체 생성
+        let urlString = ApiEndpoints.basicURLString(path: .myPage)
+        guard let url = URL(string: urlString) else {
+            print("Error: cannotCreateURL")
+            throw NetworkError.cannotCreateURL
+        }
+        
+        // 토큰 추가
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(SignInInfo.shared.accessToken())", forHTTPHeaderField: "Authorization")
+        
+        // URLSession 생성
+        let (data, response) = try await URLSession.shared.data(for: request)
+        // print(response)
+        
+        // 에러 체크
+        if let response = response as? HTTPURLResponse,
+           !(200..<300).contains(response.statusCode) {
+            print("Error: badRequest")
+            throw NetworkError.badRequest
+        }
+        
+        // 디코딩
+        let decoder = JSONDecoder()
+        let decodeData = try decoder.decode(BaseResponse<MemberResponse.MyPage>.self, from: data)
+        print("MemberResponse.MyPage: \(decodeData.result)")
+        return decodeData.result
     }
 }

--- a/Capple/Capple/Presentation/Helper/MailView.swift
+++ b/Capple/Capple/Presentation/Helper/MailView.swift
@@ -1,0 +1,58 @@
+//
+//  MailView.swift
+//  Capple
+//
+//  Created by 김민준 on 3/19/24.
+//
+
+import SwiftUI
+import UIKit
+import MessageUI
+
+// 출처: https://stackoverflow.com/questions/56784722/swiftui-send-email
+struct MailView: UIViewControllerRepresentable {
+
+    @Environment(\.presentationMode) var presentation
+    @Binding var result: Result<MFMailComposeResult, Error>?
+
+    class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+
+        @Binding var presentation: PresentationMode
+        @Binding var result: Result<MFMailComposeResult, Error>?
+
+        init(presentation: Binding<PresentationMode>,
+             result: Binding<Result<MFMailComposeResult, Error>?>) {
+            _presentation = presentation
+            _result = result
+        }
+
+        func mailComposeController(_ controller: MFMailComposeViewController,
+                                   didFinishWith result: MFMailComposeResult,
+                                   error: Error?) {
+            defer {
+                $presentation.wrappedValue.dismiss()
+            }
+            guard error == nil else {
+                self.result = .failure(error!)
+                return
+            }
+            self.result = .success(result)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(presentation: presentation,
+                           result: $result)
+    }
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<MailView>) -> MFMailComposeViewController {
+        let vc = MFMailComposeViewController()
+        vc.mailComposeDelegate = context.coordinator
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: MFMailComposeViewController,
+                                context: UIViewControllerRepresentableContext<MailView>) {
+
+    }
+}

--- a/Capple/Capple/Presentation/MyPageView/View/MyPageSection.swift
+++ b/Capple/Capple/Presentation/MyPageView/View/MyPageSection.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct MyPageSection: View {
+    
     let sectionInfo: SectionInfo
+    let sectionActions: [() -> Void]
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -21,7 +23,7 @@ struct MyPageSection: View {
                 
                 ForEach(sectionInfo.sectionContents.indices, id: \.self) { index in
                     Button {
-                        
+                        sectionActions[index]()
                     } label: {
                         HStack(spacing: 12) {
                             Image(sectionInfo.sectionIcons[index])
@@ -37,7 +39,6 @@ struct MyPageSection: View {
                     }
                     
                     Rectangle().frame(height: 1).foregroundStyle(GrayScale.stroke)
-                    
                 }
             }
         }
@@ -48,6 +49,7 @@ struct MyPageSection: View {
 
 #Preview {
     MyPageSection(sectionInfo: SectionInfo(
+        id: 0,
         sectionTitle: "질문/답변",
         sectionContents: [
             "작성한 답변",
@@ -58,5 +60,5 @@ struct MyPageSection: View {
             "WriteAnswerIcon",
             "LikeQuestionIcon",
             "LikeAnswerIcon"]
-    ))
+    ), sectionActions: [])
 }

--- a/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
+++ b/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
@@ -10,7 +10,10 @@ import SwiftUI
 struct MyPageView: View {
     
     @EnvironmentObject var pathModel: PathModel
+    @EnvironmentObject var authViewModel: AuthViewModel
     @StateObject var viewModel: MyPageViewModel = .init()
+    
+    @State private var isLogOutAlertPresented = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -50,14 +53,14 @@ struct MyPageView: View {
                         else if index.id == 1 {
                             MyPageSection(sectionInfo: index, sectionActions: [
                                 
-                                // 문의하기
+                                // 로그아웃
                                 {
-                                    print("로그아웃")
+                                    isLogOutAlertPresented = true
                                 },
                                 
                                 // 회원탈퇴
                                 {
-                                    print("회원 탈퇴")
+                                    print("회원탈퇴")
                                 }
                             ])
                         }
@@ -71,6 +74,18 @@ struct MyPageView: View {
         .onAppear {
             viewModel.requestMyPageInfo()
         }
+        .alert("로그아웃 할까요?", isPresented: $isLogOutAlertPresented) {
+            HStack {
+                Button("취소", role: .cancel, action: {})
+                Button("확인", role: .none, action: {
+                    pathModel.paths.removeAll()
+                    authViewModel.isSignIn = false
+                })
+            }
+        } message: {
+            Text("로그아웃 됩니당")
+        }
+        
     }
 }
 

--- a/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
+++ b/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
@@ -33,8 +33,34 @@ struct MyPageView: View {
                         joinDate: viewModel.myPageInfo.joinDate
                     )
                     
-                    ForEach(viewModel.sectionInfos.indices, id: \.self) { index in
-                        MyPageSection(sectionInfo: viewModel.sectionInfos[index])
+                    ForEach(viewModel.sectionInfos, id: \.id) { index in
+                        
+                        // 문의 및 제보
+                        if index.id == 0 {
+                            MyPageSection(sectionInfo: index, sectionActions: [
+                                
+                                // 문의하기
+                                {
+                                    print("문의하기")
+                                }
+                            ])
+                        }
+                        
+                        // 계정 관리
+                        else if index.id == 1 {
+                            MyPageSection(sectionInfo: index, sectionActions: [
+                                
+                                // 문의하기
+                                {
+                                    print("로그아웃")
+                                },
+                                
+                                // 회원탈퇴
+                                {
+                                    print("회원 탈퇴")
+                                }
+                            ])
+                        }
                     }
                 }
             }

--- a/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
+++ b/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
@@ -10,50 +10,10 @@ import SwiftUI
 struct MyPageView: View {
     
     @EnvironmentObject var pathModel: PathModel
-    
-    private let sectionInfos: [SectionInfo] = [
-//        SectionInfo(
-//            sectionTitle: "질문/답변",
-//            sectionContents: [
-//                "작성한 답변",
-//                "좋아요 한 질문",
-//                "좋아요 한 답변"
-//            ],
-//            sectionIcons: [
-//                "WriteAnswerIcon",
-//                "LikeQuestionIcon",
-//                "LikeAnswerIcon"]
-//        ),
-        SectionInfo(
-            sectionTitle: "문의 및 제보",
-            sectionContents: [
-                "문의하기",
-//                "캐플 디스코드",
-//                "캐플 인스타",
-//                "캐플 오픈채팅방"
-            ],
-            sectionIcons: [
-                "InquiryIcon",
-//                "DiscodeIcon",
-//                "InstagramIcon",
-//                "OpenChatIcon"
-            ]
-        ),
-        SectionInfo(
-            sectionTitle: "계정 관리",
-            sectionContents: [
-                "로그아웃",
-                "회원탈퇴"
-            ],
-            sectionIcons: [
-                "SignOutIcon",
-                "SignOutIcon"
-            ]
-        )
-    ]
+    @StateObject var viewModel: MyPageViewModel = .init()
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             CustomNavigationBar(
                 leadingView: { CustomNavigationBackButton(buttonType: .arrow) {
                     pathModel.paths.removeLast()
@@ -62,24 +22,19 @@ struct MyPageView: View {
                     Text("프로필")
                         .font(Font.pretendard(.semiBold, size: 15))
                         .foregroundStyle(TextLabel.main)
-                    
                 },
-                trailingView: {
-//                    Button {
-//                        pathModel.paths.append(.profileEdit)
-//                    } label: {
-//                        Text("수정")
-//                            .foregroundStyle(TextLabel.sub3)
-//                    }
-                },
+                trailingView: {},
                 backgroundColor: Background.second)
+            
             ScrollView {
-                
                 VStack(alignment: .leading, spacing: 0) {
-                    MyProfileSummary()
+                    MyProfileSummary(
+                        nickname: viewModel.myPageInfo.nickname,
+                        joinDate: viewModel.myPageInfo.joinDate
+                    )
                     
-                    ForEach(sectionInfos.indices, id: \.self) { index in
-                        MyPageSection(sectionInfo: sectionInfos[index])
+                    ForEach(viewModel.sectionInfos.indices, id: \.self) { index in
+                        MyPageSection(sectionInfo: viewModel.sectionInfos[index])
                     }
                 }
             }
@@ -87,13 +42,10 @@ struct MyPageView: View {
         .background(Background.second)
         .navigationBarBackButtonHidden()
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            viewModel.requestMyPageInfo()
+        }
     }
-}
-
-struct SectionInfo {
-    var sectionTitle: String
-    var sectionContents: [String]
-    var sectionIcons: [String]
 }
 
 #Preview {

--- a/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
+++ b/Capple/Capple/Presentation/MyPageView/View/MyPageView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import MessageUI
 
 struct MyPageView: View {
     
@@ -14,6 +15,11 @@ struct MyPageView: View {
     @StateObject var viewModel: MyPageViewModel = .init()
     
     @State private var isLogOutAlertPresented = false
+    
+    // 이메일 관련 변수
+    @State private var mailResult: Result<MFMailComposeResult, Error>? = nil
+    @State private var isShowingMailView = false
+    @State private var isEmailDisabledAlert = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -44,7 +50,12 @@ struct MyPageView: View {
                                 
                                 // 문의하기
                                 {
-                                    print("문의하기")
+                                    // 메일 앱을 사용할 수 없는 경우
+                                    if !MFMailComposeViewController.canSendMail() {
+                                        isEmailDisabledAlert.toggle()
+                                    } else {
+                                        isShowingMailView.toggle()
+                                    }
                                 }
                             ])
                         }
@@ -55,7 +66,7 @@ struct MyPageView: View {
                                 
                                 // 로그아웃
                                 {
-                                    isLogOutAlertPresented = true
+                                    isLogOutAlertPresented.toggle()
                                 },
                                 
                                 // 회원탈퇴
@@ -85,7 +96,14 @@ struct MyPageView: View {
         } message: {
             Text("로그아웃 됩니당")
         }
-        
+        .alert("메일 APP을 사용할 수 없어요", isPresented: $isEmailDisabledAlert) {
+            Button("확인", role: .none, action: {})
+        } message: {
+            Text("메일 APP 설치 후 로그인 해주세요.\n혹은 공식 문의 메일 - 0.team.capple@gmail.com")
+        }
+        .sheet(isPresented: $isShowingMailView) {
+            MailView(result: $mailResult)
+        }
     }
 }
 

--- a/Capple/Capple/Presentation/MyPageView/View/MyProfileSummary.swift
+++ b/Capple/Capple/Presentation/MyPageView/View/MyProfileSummary.swift
@@ -15,7 +15,8 @@ struct MyProfileSummary: View {
     
     var body: some View {
         HStack(spacing: 16) {
-            // 임시
+            
+            // MARK: - 프로필 이미지 없을 시 기본값 생성
             Image(profileImage ?? "Capple")
                 .resizable()
                 .frame(width: 72, height: 72)

--- a/Capple/Capple/Presentation/MyPageView/View/MyProfileSummary.swift
+++ b/Capple/Capple/Presentation/MyPageView/View/MyProfileSummary.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct MyProfileSummary: View {
-    var nickname: String = "튼튼한 당근"
-    var joinDate: String = "2024.02.09"
+    
+    var nickname: String
+    var joinDate: String
+    var profileImage: String?
     
     var body: some View {
         HStack(spacing: 16) {
             // 임시
-            Image("Capple")
+            Image(profileImage ?? "Capple")
                 .resizable()
                 .frame(width: 72, height: 72)
                 .background(Color.white)
@@ -26,7 +28,7 @@ struct MyProfileSummary: View {
                     .font(Font.pretendard(.bold, size: 20))
                     .frame(height: 14)
                 
-                Text("\(joinDate) 가입")
+                Text("\(joinDate)")
                     .foregroundStyle(TextLabel.sub3)
                     .font(Font.pretendard(.semiBold, size: 14))
                     .frame(height: 10)
@@ -40,5 +42,8 @@ struct MyProfileSummary: View {
 }
 
 #Preview {
-    MyProfileSummary()
+    MyProfileSummary(
+        nickname: "튼튼한 당근",
+        joinDate: "2024.02.09"
+    )
 }

--- a/Capple/Capple/Presentation/MyPageView/ViewModel/MyPageViewModel.swift
+++ b/Capple/Capple/Presentation/MyPageView/ViewModel/MyPageViewModel.swift
@@ -1,0 +1,65 @@
+//
+//  MyPageViewModel.swift
+//  Capple
+//
+//  Created by 김민준 on 3/19/24.
+//
+
+import Foundation
+
+struct SectionInfo {
+    var sectionTitle: String
+    var sectionContents: [String]
+    var sectionIcons: [String]
+}
+
+final class MyPageViewModel: ObservableObject {
+    
+    // 섹션 정보
+    let sectionInfos: [SectionInfo] = [
+        SectionInfo(
+            sectionTitle: "문의 및 제보",
+            sectionContents: [
+                "문의하기",
+            ],
+            sectionIcons: [
+                "InquiryIcon",
+            ]
+        ),
+        SectionInfo(
+            sectionTitle: "계정 관리",
+            sectionContents: [
+                "로그아웃",
+                "회원탈퇴"
+            ],
+            sectionIcons: [
+                "SignOutIcon",
+                "SignOutIcon"
+            ]
+        )
+    ]
+    
+    // 프로필 정보
+    @Published var myPageInfo: MemberResponse.MyPage
+    
+    init() {
+        self.myPageInfo = .init(nickname: "튼튼한 민톨", profileImage: nil, joinDate: "2024.03.19 가입")
+    }
+}
+
+// MARK: - 네트워킹
+extension MyPageViewModel {
+    
+    /// 마이페이지 정보를 업데이트합니다.
+    @MainActor
+    func requestMyPageInfo() {
+        Task {
+            do {
+                self.myPageInfo = try await NetworkManager.requestMyPage()
+                print("마이페이지 정보 로드 성공")
+            } catch {
+                print("마이페이지 정보 로드 실패")
+            }
+        }
+    }
+}

--- a/Capple/Capple/Presentation/MyPageView/ViewModel/MyPageViewModel.swift
+++ b/Capple/Capple/Presentation/MyPageView/ViewModel/MyPageViewModel.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-struct SectionInfo {
+struct SectionInfo: Identifiable {
+    let id: Int
     var sectionTitle: String
     var sectionContents: [String]
     var sectionIcons: [String]
@@ -18,6 +19,7 @@ final class MyPageViewModel: ObservableObject {
     // 섹션 정보
     let sectionInfos: [SectionInfo] = [
         SectionInfo(
+            id: 0,
             sectionTitle: "문의 및 제보",
             sectionContents: [
                 "문의하기",
@@ -27,6 +29,7 @@ final class MyPageViewModel: ObservableObject {
             ]
         ),
         SectionInfo(
+            id: 1,
             sectionTitle: "계정 관리",
             sectionContents: [
                 "로그아웃",

--- a/Capple/Capple/Presentation/SignInView/ViewModel/AuthViewModel.swift
+++ b/Capple/Capple/Presentation/SignInView/ViewModel/AuthViewModel.swift
@@ -119,7 +119,7 @@ extension AuthViewModel {
     }
 }
 
-// MARK: - 이메일 인증
+// MARK: - 대학 이메일 인증
 extension AuthViewModel {
     
     /// 대학 이메일 인증을 요청합니다.

--- a/Capple/Capple/Presentation/TodayQuestionView/View/AnswerCell.swift
+++ b/Capple/Capple/Presentation/TodayQuestionView/View/AnswerCell.swift
@@ -11,6 +11,7 @@ import FlexView
 struct AnswerCell: View {
     
     var profileName: String
+    var profileImage: String?
     var answer: String
     var keywords: [String]
     let seeMoreAction: () -> Void
@@ -19,7 +20,9 @@ struct AnswerCell: View {
         HStack(alignment: .top) {
             
             // 프로필 이미지
-            Image(.profileDummy)
+            Image(
+                profileImage != nil && !profileImage!.isEmpty ?profileImage! : "profileDummyImage"
+            )
                 .resizable()
                 .frame(width: 28, height: 28)
             

--- a/Capple/Capple/Presentation/TodayQuestionView/View/TodayQuestionView.swift
+++ b/Capple/Capple/Presentation/TodayQuestionView/View/TodayQuestionView.swift
@@ -275,7 +275,12 @@ private struct AnswerPreview: View {
                             
                             if viewModel.state != .ready {
                                 SeeAllButton {
-                                    pathModel.paths.append(.answer)
+                                    pathModel.paths.append(
+                                        .todayAnswer(
+                                            questionId: viewModel.mainQuestion.questionId,
+                                            questionContent: viewModel.mainQuestion.content
+                                        )
+                                    )
                                 }
                             }
                         }

--- a/Capple/Capple/Presentation/TodayQuestionView/View/TodayQuestionView.swift
+++ b/Capple/Capple/Presentation/TodayQuestionView/View/TodayQuestionView.swift
@@ -212,7 +212,12 @@ private struct HeaderButtonView: View {
                 if viewModel.state == .ready {
                     pathModel.paths.append(.answer)
                 } else {
-                    tab = .collecting
+                    pathModel.paths.append(
+                        .todayAnswer(
+                            questionId: viewModel.mainQuestion.questionId,
+                            questionContent: viewModel.mainQuestion.content
+                        )
+                    )
                 }
             }
         }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정

## 반영 브랜치
80-feat-api-연결-및-마이페이지-뷰-업데이트 -> develop

## 변경 사항
- 전체보기 path 수정
- 이전 질문 보기 path 수정
- 마이페이지 정보 API 연결
- 마이페이지 문의하기 메일 연동 기능 추가
- 마이페이지 로그아웃 기능 추가
- AnswerCell profileImage 보이는 방식 변경

## 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
