### PR TITLE
[FEAT] 질문모아보기 뷰 상태텍스트 live일때만 표시 및 답변모아보기 플로팅카드 수정 

### DIFF
--- a/Capple/Capple/Presentation/SearchResultView/View/QuestionView.swift
+++ b/Capple/Capple/Presentation/SearchResultView/View/QuestionView.swift
@@ -73,14 +73,16 @@ struct QuestionView: View {
         switch questions.questionStatus {
         case .live:
             return QuestionStatus.live.rawValue
+        /*
         case .old:
             return QuestionStatus.old.rawValue
         case .hold:
             return QuestionStatus.hold.rawValue
         case .pending:
             return QuestionStatus.pending.rawValue
+         */
         default:
-            return "UNKNOWN"
+            return ""
         }
     }
     
@@ -115,15 +117,16 @@ struct QuestionView: View {
                 Spacer()
                     .frame(width: 8)
                 
-                Text(questionStatusRawValue)
-                    .font(.pretendard(.bold, size: 9))
-                    .foregroundStyle(.wh)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
-                    .background(Context.onAir)
-                    .cornerRadius(18, corners: .allCorners)
-                
-                
+                if !questionStatusRawValue.isEmpty{
+                    Text(questionStatusRawValue)
+                        .font(.pretendard(.bold, size: 9))
+                        .foregroundStyle(.wh)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(Context.onAir)
+                        .cornerRadius(18, corners: .allCorners)
+                    
+                }
                 Spacer()
                 
                 HStack(alignment: .center) {

--- a/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
@@ -33,7 +33,6 @@ struct SingleAnswerView: View {
         //  if !sharedData.innerShowingReportSheet  {
         
             HStack (alignment: .top){
-                
                 Image(answer.profileImage != nil && !answer.profileImage!.isEmpty ? answer.profileImage! : "profileDummyImage")
                     .resizable()
                     .frame(width: 28, height: 28)
@@ -44,7 +43,7 @@ struct SingleAnswerView: View {
                 
                 VStack(alignment: .leading) {
                     HStack{
-                            Text(answer.nickname ?? "nickname") // 유저 닉네임 표시합니다.
+                            Text(answer.nickname ?? "nickname")
                                 .font(.pretendard(.semiBold, size: 14))
                                 .foregroundStyle(TextLabel.sub2)
                                 .frame(height: 10)

--- a/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/SingleAnswerView.swift
@@ -29,69 +29,73 @@ struct SingleAnswerView: View {
   //  @State private var reportButtonPosition: CGPoint? = nil // Report 버튼의 위치
     
     var body: some View {
-        //   ZStack{
-        //  if !sharedData.innerShowingReportSheet  {
         
-            HStack (alignment: .top){
-                Image(answer.profileImage != nil && !answer.profileImage!.isEmpty ? answer.profileImage! : "profileDummyImage")
-                    .resizable()
-                    .frame(width: 28, height: 28)
-                    .clipShape(Circle())
-                
-                Spacer()
-                    .frame(width: 8)
-                
-                VStack(alignment: .leading) {
-                    HStack{
-                            Text(answer.nickname ?? "nickname")
-                                .font(.pretendard(.semiBold, size: 14))
-                                .foregroundStyle(TextLabel.sub2)
-                                .frame(height: 10)
-                                .padding(.top, 8)
-                         
-                            Spacer()
-                            
-                            Button {
-                                //showingReportSheet = true
-                                seeMoreAction()
-                                
-                                
-                            } label: {
-                                Image(systemName: "ellipsis")
-                                    .foregroundStyle(TextLabel.sub2)
-                                    .frame(width: 20, height: 20)
+        HStack(alignment: .top, spacing: 8) {
+                    VStack{
+                        Image(answer.profileImage != nil && !answer.profileImage!.isEmpty ? answer.profileImage! : "profileDummyImage")
+                            .resizable()
+                            .frame(width: 28, height: 28)
+                            .clipShape(Circle())
+                    }
+                    VStack{
+                        VStack(alignment: .leading){
+                            HStack (alignment: .center){
+                                HStack{
+                                    Text(answer.nickname ?? "nickname")
+                                        .font(.pretendard(.semiBold, size: 14))
+                                        .foregroundStyle(TextLabel.sub2)
+                                        .frame(height: 10)
+                                    
+                                    
+                                    Spacer()
+                                    
+                                    Button {
+                                        //showingReportSheet = true
+                                        seeMoreAction()
+                                        
+                                        
+                                    } label: {
+                                        Image(systemName: "ellipsis")
+                                            .foregroundStyle(TextLabel.sub2)
+                                            .frame(width: 20, height: 20)
+                                    }
+                                }
                             }
-                        
-                    }
-                    Spacer()
-                        .frame(height: 12)
-                    
-                    Text(answer.content ?? "content")
-                        .font(.pretendard(.medium, size: 16))
-                        .foregroundStyle(TextLabel.main)
-                        .lineLimit(.max)
-                        .lineSpacing(6)
-                        .multilineTextAlignment(.leading)
-                        
-                    
-                    Spacer()
-                        .frame(height: 12)
-                     
-                    HStack {
-                        ForEach(answer.tags?.split(separator: " ").map(String.init) ?? [], id: \.self) { tag in
-                            Text("#\(tag)")
-                                .font(.pretendard(.semiBold, size: 14))
-                                .foregroundColor(BrandPink.text)
-                            
-                            Spacer()
-                                .frame(width: 8)
-                            
                         }
-                     
+                        
+                        Spacer().frame(height: 8)
+                        
+                        VStack(alignment: .leading) {
+                               Text(answer.content ?? "content")
+                                   .font(.pretendard(.medium, size: 16))
+                                   .foregroundStyle(TextLabel.main)
+                                   .lineLimit(nil)
+                                   .lineSpacing(6)
+                                   .multilineTextAlignment(.leading)
+                                   .frame(maxWidth: .infinity, alignment: .leading) // 왼쪽 정렬
+
+                            Spacer()
+                                .frame(height: 12)
+
+                               HStack(alignment: .top, spacing: 8) {
+                                   ForEach(answer.tags?.split(separator: " ").map(String.init) ?? [], id: \.self) { tag in
+                                       Text("#\(tag)")
+                                           .font(.pretendard(.semiBold, size: 14))
+                                           .foregroundColor(BrandPink.text)
+                                   }
+                               }
+                               .frame( alignment: .leading)
+                           }
+                      //  Spacer()
+                           
                     }
-                     
-                }
+                 //   .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                .padding(24)
+                
                
+     //           }
+     
             
                 
               
@@ -107,14 +111,14 @@ struct SingleAnswerView: View {
                  */
             }
            
-        }
+    }
         /*
             .onTapGesture {
                 self.innerShowingReportSheet = true
                 
             }
          */
-    }
+  //  }
 
             /*
             else if sharedData.showingReportSheet && !sharedData.innerShowingReportSheet {

--- a/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
@@ -181,7 +181,7 @@ private struct AnswerScrollView: View {
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
                 ForEach(Array(viewModel.answers.enumerated()), id: \.offset) { index, answer in
-                    LazyVStack(spacing: 24){
+                    LazyVStack{
                         SingleAnswerView(answer: answer){
                             isBottomSheetPresented.toggle()
                         }
@@ -196,7 +196,7 @@ private struct AnswerScrollView: View {
                     /*
                         .onTapGesture {self.sharedData.reportButtonPosition = CGPoint(x: 270, y: -index * 100)            }
                      */
-                        .padding(.horizontal, 24)
+                     //   .padding(.horizontal, 24)
                         .sheet(isPresented: $isBottomSheetPresented) {
                             SeeMoreView(isBottomSheetPresented: $isBottomSheetPresented)
                                 .presentationDetents([.height(84)])
@@ -205,16 +205,11 @@ private struct AnswerScrollView: View {
                    
                     }
                     //.padding(.bottom, 16)
-                    Spacer()
-                        .frame(height: 32)
+              //      Spacer()
+                //        .frame(height: 32)
         }
-                if viewModel.isLoading {
-                    ProgressView()
-                        .scaleEffect(1.5)
-                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                        .padding(.vertical, 20)
-                }
-            }
+ 
+        }
     }
 }
 

--- a/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
@@ -15,8 +15,10 @@ struct TodayAnswerView: View {
     
     @ObservedObject var viewModel: TodayAnswersViewModel
     @State private var isBottomSheetPresented = false
-    
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    
+  
+    
     
     init(questionId: Int, tab: Binding<Tab>, questionContent: String) {
         self.viewModel = TodayAnswersViewModel(questionId: questionId )
@@ -104,21 +106,38 @@ private struct FloatingQuestionCard: View {
      @Binding var tab: Tab // 현재 탭을 저장할 프로퍼티
      @ObservedObject var viewModel: TodayAnswersViewModel // 뷰 모델
      @State private var isCardExpanded = true // 카드 확장 상태
-
     var questionId: Int?  // 추가됨
     
+    
+    var todayQuestionText: AttributedString {
+        var questionMark = AttributedString("Q. ")
+        questionMark.foregroundColor = BrandPink.text
+        let creatingText = AttributedString("\(questionContent)")
+        print(questionContent, "TodayAnswersViewModel에서 todayQuestion 스트링")
+        return questionMark + creatingText
+    }
  
     var body: some View {
         HStack {
-            Text(questionContent)
+            Text(todayQuestionText)
                 .font(.pretendard(.semiBold, size: 15))
                 .foregroundStyle(TextLabel.main)
                 .lineLimit(isCardExpanded ? 3 : 0)
-            Spacer() // 화살표를 오른쪽으로 밀어내기 위해 Spacer 추가
-            
+            Spacer()
+            Image(isCardExpanded ? .arrowUp : .arrowDown)
+                       .resizable()
+                       .frame(width: 28, height: 28)
+                       .foregroundColor(.white)
+               }
+               .onTapGesture {
+                   withAnimation {
+                       isCardExpanded.toggle() // 확장/축소 상태 토글
+                   }
+               }
+        /*
             Button {
                 withAnimation {
-                    isCardExpanded.toggle() // 버튼 클릭 시 카드 확장/축소 상태 토글
+                    isCardExpanded.toggle()
                 }
             } label: {
                 Image(isCardExpanded ? .arrowUp : .arrowDown)
@@ -126,7 +145,8 @@ private struct FloatingQuestionCard: View {
                     .frame(width: 28, height: 28)
                     .foregroundColor(.white)
             }
-        }
+         */
+        
         .padding(14)
         .frame(maxWidth: .infinity)
         .background(GrayScale.secondaryButton)
@@ -182,9 +202,9 @@ private struct AnswerScrollView: View {
                                 .presentationDetents([.height(84)])
                         }
                         Separator()
-                            .padding(.leading, 24)
                    
-                    }.padding(.bottom, 16)
+                    }
+                    //.padding(.bottom, 16)
                     Spacer()
                         .frame(height: 32)
         }
@@ -203,3 +223,6 @@ struct TodayAnswerView_Previews: PreviewProvider {
         TodayAnswerView(questionId: 1, tab: .constant(.answering), questionContent: "디폴트")
     }
 }
+
+
+

--- a/Capple/Capple/Presentation/TodayAnswersView/ViewModel/TodayAnswerViewModel.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/ViewModel/TodayAnswerViewModel.swift
@@ -95,16 +95,3 @@ class TodayAnswersViewModel: ObservableObject {
 */
     
 
-
-// MARK: - 텍스트 반환
-extension TodayAnswersViewModel {
-    /// 오늘의 질문 텍스트를 반환합니다.
-    var todayQuestionText: AttributedString {
-        var questionMark = AttributedString("Q. ")
-        questionMark.foregroundColor = BrandPink.text
-        let creatingText = AttributedString("\(todayQuestion)")
-        print(todayQuestion, "TodayAnswersViewModel에서 todayQuestion 스트링")
-        return questionMark + creatingText
-    }
-}
-

--- a/Capple/Capple/Presentation/TodayQuestionView/View/AnswerCell.swift
+++ b/Capple/Capple/Presentation/TodayQuestionView/View/AnswerCell.swift
@@ -37,6 +37,7 @@ struct AnswerCell: View {
                         .foregroundStyle(TextLabel.sub2)
                         .frame(height: 10)
                         .padding(.top, 8)
+                        
                     
                     Spacer()
                     
@@ -51,7 +52,7 @@ struct AnswerCell: View {
                 }
                 
                 Spacer()
-                    .frame(height: 12)
+                    .frame(height: 8)
                 
                 // 답변
                 Text(answer)


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정

## 반영 브랜치
Feature/#82/today answer view search result view view update -> develop

## 변경 사항

[AnswerCell, SingleAnswerView] - 추가수정필요 
* [-ing] 셀 크기 수정 필요(밑에 영역이 커보이는 듯함)
[SearchResultView] - 뷰적인 부분 완료 
* [X] 질문이 LIVE 상태일 때만 표시 필요. (현재는 다른 상태에도 모두 적용되는 듯)
* [] 화면이 이동될 때 깜빡이는 현상? (아마 데이터가 다시 불러와지고 있는 것 같은데 살펴볼 필요 있을듯)
[TodayAnswerView] - 완료
* [X] 메인 질문 Q. 누락
* [X] 메인 질문 창이 오른쪽 화살표 버튼을 눌렀을 때만 접히고 열림 → 영역 전체 탭했을 때로 수정 필요


## 테스트 결과
- old 인 질문 상태표시 안되는 것 확인 

<img width="304" alt="스크린샷 2024-03-20 오전 12 40 00" src="https://github.com/Team-Capple/Capple-iOS/assets/97822063/d68ae33a-a5a3-4ae0-8adb-4f4eb2dfc331">

- 메인질문 Q 누락 및 전체 플로팅카드 탭했을때 열고닫고 가능하도록 수정 확인 

<img width="299" alt="스크린샷 2024-03-20 오전 12 39 50" src="https://github.com/Team-Capple/Capple-iOS/assets/97822063/8a4ee72d-6d7e-4f9c-9570-c93d74a93cc8">

