### PR TITLE
[FEAT] 답변모아보기 뷰 플로팅카드 수정 

### DIFF
--- a/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
+++ b/Capple/Capple/Presentation/TodayAnswersView/View/TodayAnswerView.swift
@@ -109,23 +109,28 @@ private struct FloatingQuestionCard: View {
     var questionId: Int?  // 추가됨
     
     
-    var todayQuestionText: AttributedString {
+    var questionMark: AttributedString {
         var questionMark = AttributedString("Q. ")
         questionMark.foregroundColor = BrandPink.text
+        return questionMark
+    }
+    var creatingText: AttributedString {
         let creatingText = AttributedString("\(questionContent)입니다릿다릿두줄입니다릿다릿")
-        print(questionContent, "TodayAnswersViewModel에서 todayQuestion 스트링")
-        return questionMark + creatingText
+        return creatingText
     }
  
     var body: some View {
         HStack {
-            Text(todayQuestionText)
-                .font(.pretendard(.semiBold, size: 15))
-                .foregroundStyle(TextLabel.main)
-            
-            
-                .lineSpacing(6)
-                .lineLimit(isCardExpanded ? 3 : 0)
+            HStack(alignment: .top){
+                Text(questionMark)
+                    .font(.pretendard(.semiBold, size: 15))
+                    .foregroundStyle(TextLabel.main)
+                Text(creatingText)
+                    .font(.pretendard(.semiBold, size: 15))
+                    .foregroundStyle(TextLabel.main)
+                    .lineSpacing(6)
+                    .lineLimit(isCardExpanded ? 3 : 0)
+            }
             Spacer()
             Image(isCardExpanded ? .arrowUp : .arrowDown)
                        .resizable()


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정

## 반영 브랜치
feature/#86/AnswerCell_SingleAnswerView_viewUpdate -> develop

## 변경 사항
- 답변모아보기 뷰에서 플로팅카드 수정 

## 테스트 결과
<img width="372" alt="스크린샷 2024-03-20 오후 10 56 29" src="https://github.com/Team-Capple/Capple-iOS/assets/97822063/d1746960-3980-420d-9dd7-dcb170699a56">

