### PR TITLE
[Feat/#170] 게시판 아카데미 일정 DayCounter 추가

### DIFF
--- a/Qapple/Qapple/Component/Info/AcademyPlanDayCounter.swift
+++ b/Qapple/Qapple/Component/Info/AcademyPlanDayCounter.swift
@@ -12,12 +12,22 @@ import SwiftUI
 struct AcademyPlanDayCounter: View {
     
     let currentEvent: String
-    let progress: Double
+    let startDate: Date
+    let endDate: Date
+    
+    var dayLeftUntilNextEvent: Int {
+        let calendar = Calendar.current
+        let difference = calendar.dateComponents([.day], from: .now, to: endDate)
+        return difference.day ?? 0
+    }
     
     var body: some View {
         VStack(spacing: 8) {
             HStack {
-                CurrentEventTitle(currentEvent: currentEvent)
+                CurrentEventTitle(
+                    currentEvent: currentEvent,
+                    dayLeftUntilNextEvent: dayLeftUntilNextEvent
+                )
                 
                 Spacer()
                 
@@ -27,7 +37,11 @@ struct AcademyPlanDayCounter: View {
                     .frame(width: 54, height: 54)
             }
             
-            ProgressBar(progress: progress)
+            ProgressBar(
+                startDate: startDate,
+                endDate: endDate,
+                dayLeftUntilNextEvent: dayLeftUntilNextEvent
+            )
         }
         .padding(.vertical, 16)
         .padding(.horizontal, 20)
@@ -41,7 +55,7 @@ struct AcademyPlanDayCounter: View {
 private struct CurrentEventTitle: View {
     
     let currentEvent: String
-    let dayLeftUntilNextEvent = 23
+    let dayLeftUntilNextEvent: Int
     
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -50,9 +64,10 @@ private struct CurrentEventTitle: View {
                     .foregroundStyle(BrandPink.text)
                     .pretendard(.bold, 23)
                 
-                Text("까지")
+                Text("종료까지")
                     .foregroundStyle(TextLabel.main)
                     .pretendard(.semiBold, 15)
+                    .padding(.bottom, -2)
             }
             
             Text("D-\(dayLeftUntilNextEvent)")
@@ -66,7 +81,15 @@ private struct CurrentEventTitle: View {
 
 private struct ProgressBar: View {
     
-    let progress: Double
+    let startDate: Date
+    let endDate: Date
+    let dayLeftUntilNextEvent: Int
+    
+    var progress: Double {
+        let calendar = Calendar.current
+        let total = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+        return Double(total - dayLeftUntilNextEvent) / Double(total)
+    }
     
     var body: some View {
         GeometryReader { proxy in
@@ -74,6 +97,7 @@ private struct ProgressBar: View {
                 RoundedRectangle(cornerRadius: 10)
                     .foregroundStyle(TextLabel.placeholder)
                     .frame(width: proxy.size.width)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
                 
                 RoundedRectangle(cornerRadius: 10)
                     .foregroundStyle(BrandPink.button)
@@ -89,6 +113,7 @@ private struct ProgressBar: View {
 #Preview {
     AcademyPlanDayCounter(
         currentEvent: "Prologue",
-        progress: 0.37
+        startDate: .now,
+        endDate: .now
     )
 }

--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardUseCase.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardUseCase.swift
@@ -11,9 +11,25 @@ final class BulletinBoardUseCase: ObservableObject {
     @Published var _state: State
     
     init() {
+        
+        // 매크로 시작 날
+        var startDateComponents = DateComponents()
+        startDateComponents.year = 2024
+        startDateComponents.month = 9
+        startDateComponents.day = 2
+        
+        // 매크로 종료 날
+        var endDateComponents = DateComponents()
+        endDateComponents.year = 2024
+        endDateComponents.month = 11
+        endDateComponents.day = 29
+        
+        let calendar = Calendar.current
+        
         self._state = State(
-            currentEvent: "Prologue", // TODO: 실제 값 업데이트
-            progress: 0.47, // TODO: 실제 값 업데이트
+            currentEvent: "Macro", // TODO: 실제 값 업데이트
+            startDate: calendar.date(from: startDateComponents)!, // TODO: 실제 값 업데이트
+            endDate: calendar.date(from: endDateComponents)!, // TODO: 실제 값 업데이트
             posts: dummyPosts // TODO: 실제 게시글 업데이트
         )
     }
@@ -25,7 +41,8 @@ extension BulletinBoardUseCase {
     
     struct State {
         let currentEvent: String
-        let progress: Double
+        let startDate: Date
+        let endDate: Date
         let posts: [Post]
     }
 }

--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardView.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardView.swift
@@ -60,7 +60,8 @@ private struct BoardView: View {
             
             AcademyPlanDayCounter(
                 currentEvent: bulletinBoardUseCase._state.currentEvent,
-                progress: bulletinBoardUseCase._state.progress
+                startDate: bulletinBoardUseCase._state.startDate,
+                endDate: bulletinBoardUseCase._state.endDate
             )
             .padding(.top, 20)
             .padding(.horizontal, 16)


### PR DESCRIPTION
## 변경 사항
- 게시판 아카데미 일정 DayCounter 추가

## 테스트 결과
![image](https://github.com/user-attachments/assets/e5e8e43a-f90e-4ecd-a17d-6256bc836236)

## 팀원 코멘트
| 일단 더미데이터로 넣어뒀슴당!
추가로 날짜가 조금 지났을 때는 괜찮은데 스크린샷 처럼 조금만 차있을 때는 비율이 좀 이상해지더라구요,, 나중에 수정해봐야겠습니다!
