### PR TITLE
#181 / 댓글View api 연결(댓글 불러오기), ApiEndPoints 추가, 모델 수정

### DIFF
--- a/Qapple/Qapple.xcodeproj/project.pbxproj
+++ b/Qapple/Qapple.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		2C2E0ED52C63D177003928C1 /* CommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2E0ED42C63D177003928C1 /* CommentCell.swift */; };
 		2C2E0ED72C646EC9003928C1 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2E0ED62C646EC9003928C1 /* CommentView.swift */; };
 		2CD2B5A52C77192600E17B6A /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A42C77192600E17B6A /* Pretendard-Light.otf */; };
-		2CD2B5A72C771C3500E17B6A /* CommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A62C771C3500E17B6A /* CommentUseCase.swift */; };
+		2CD2B5A72C771C3500E17B6A /* CommentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A62C771C3500E17B6A /* CommentViewModel.swift */; };
 		2CD2B5A92C88753800E17B6A /* NetworkManager + Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A82C88753800E17B6A /* NetworkManager + Comment.swift */; };
 		2CD2B5AB2C88780D00E17B6A /* CommentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5AA2C88780D00E17B6A /* CommentResponse.swift */; };
 		2CD2B5AD2C88789C00E17B6A /* CommentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5AC2C88789C00E17B6A /* CommentRequest.swift */; };
@@ -199,7 +199,7 @@
 		2C2E0ED42C63D177003928C1 /* CommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCell.swift; sourceTree = "<group>"; };
 		2C2E0ED62C646EC9003928C1 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		2CD2B5A42C77192600E17B6A /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
-		2CD2B5A62C771C3500E17B6A /* CommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentUseCase.swift; sourceTree = "<group>"; };
+		2CD2B5A62C771C3500E17B6A /* CommentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentViewModel.swift; sourceTree = "<group>"; };
 		2CD2B5A82C88753800E17B6A /* NetworkManager + Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkManager + Comment.swift"; sourceTree = "<group>"; };
 		2CD2B5AA2C88780D00E17B6A /* CommentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentResponse.swift; sourceTree = "<group>"; };
 		2CD2B5AC2C88789C00E17B6A /* CommentRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRequest.swift; sourceTree = "<group>"; };
@@ -493,7 +493,7 @@
 			children = (
 				2C2E0ED42C63D177003928C1 /* CommentCell.swift */,
 				2C2E0ED62C646EC9003928C1 /* CommentView.swift */,
-				2CD2B5A62C771C3500E17B6A /* CommentUseCase.swift */,
+				2CD2B5A62C771C3500E17B6A /* CommentViewModel.swift */,
 			);
 			path = CommentView;
 			sourceTree = "<group>";
@@ -1328,7 +1328,7 @@
 				073C3DE22B871F130016C333 /* TimeInterval+Extension.swift in Sources */,
 				824717342BC9144F005E9631 /* ReportType.swift in Sources */,
 				82F7041F2C6DD29D00479206 /* TabType.swift in Sources */,
-				2CD2B5A72C771C3500E17B6A /* CommentUseCase.swift in Sources */,
+				2CD2B5A72C771C3500E17B6A /* CommentViewModel.swift in Sources */,
 				2CD2B5A92C88753800E17B6A /* NetworkManager + Comment.swift in Sources */,
 				F3D452D52B8A647F000BA51C /* UINavigationController+Extension.swift in Sources */,
 				828715C02B9AC866001627DB /* AnswerRequest.swift in Sources */,

--- a/Qapple/Qapple.xcodeproj/project.pbxproj
+++ b/Qapple/Qapple.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		2C2E0ED72C646EC9003928C1 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2E0ED62C646EC9003928C1 /* CommentView.swift */; };
 		2CD2B5A52C77192600E17B6A /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A42C77192600E17B6A /* Pretendard-Light.otf */; };
 		2CD2B5A72C771C3500E17B6A /* CommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A62C771C3500E17B6A /* CommentUseCase.swift */; };
+		2CD2B5A92C88753800E17B6A /* NetworkManager + Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A82C88753800E17B6A /* NetworkManager + Comment.swift */; };
+		2CD2B5AB2C88780D00E17B6A /* CommentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5AA2C88780D00E17B6A /* CommentResponse.swift */; };
+		2CD2B5AD2C88789C00E17B6A /* CommentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5AC2C88789C00E17B6A /* CommentRequest.swift */; };
 		420D72012C71D53200B56439 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 420D72002C71D53200B56439 /* GoogleService-Info.plist */; };
 		420D72052C71D5BB00B56439 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 420D72042C71D5BB00B56439 /* FirebaseAuth */; };
 		420D720B2C71D81400B56439 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420D720A2C71D81400B56439 /* AppDelegate.swift */; };
@@ -197,6 +200,9 @@
 		2C2E0ED62C646EC9003928C1 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		2CD2B5A42C77192600E17B6A /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		2CD2B5A62C771C3500E17B6A /* CommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentUseCase.swift; sourceTree = "<group>"; };
+		2CD2B5A82C88753800E17B6A /* NetworkManager + Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkManager + Comment.swift"; sourceTree = "<group>"; };
+		2CD2B5AA2C88780D00E17B6A /* CommentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentResponse.swift; sourceTree = "<group>"; };
+		2CD2B5AC2C88789C00E17B6A /* CommentRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRequest.swift; sourceTree = "<group>"; };
 		420D72002C71D53200B56439 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		420D720A2C71D81400B56439 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4213DF752C6E1F86007F433C /* NotificationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationUseCase.swift; sourceTree = "<group>"; };
@@ -559,6 +565,7 @@
 				8295BDB72BA322E600115FA8 /* NetworkManager+Tag.swift */,
 				8295BDB92BA3231000115FA8 /* NetworkManager+Member.swift */,
 				824717352BC9163C005E9631 /* NetworkManager+Report.swift */,
+				2CD2B5A82C88753800E17B6A /* NetworkManager + Comment.swift */,
 			);
 			name = NetworklManager;
 			sourceTree = "<group>";
@@ -974,6 +981,7 @@
 				828715C12B9AC91A001627DB /* AnswerResponse.swift */,
 				8295BDB32BA3222200115FA8 /* MemberResponse.swift */,
 				824717312BC9140A005E9631 /* ReportResponse.swift */,
+				2CD2B5AA2C88780D00E17B6A /* CommentResponse.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -986,6 +994,7 @@
 				828715BF2B9AC866001627DB /* AnswerRequest.swift */,
 				8295BDB12BA3209000115FA8 /* MemberRequest.swift */,
 				8247172F2BC913B9005E9631 /* ReportRequest.swift */,
+				2CD2B5AC2C88789C00E17B6A /* CommentRequest.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1286,6 +1295,7 @@
 				4213DF762C6E1F86007F433C /* NotificationUseCase.swift in Sources */,
 				828908F92C6DCD3500C7F6CD /* BulletinPostingUseCase.swift in Sources */,
 				82C3791B2B93499300CC7708 /* Alert.swift in Sources */,
+				2CD2B5AD2C88789C00E17B6A /* CommentRequest.swift in Sources */,
 				828A03DB2BAB36F80038CF91 /* NotificationManager.swift in Sources */,
 				F36F37C32B9B7A29002EC36B /* AppleLoginButton.swift in Sources */,
 				8295BDB02BA31C5C00115FA8 /* PrivacyDocument.swift in Sources */,
@@ -1319,11 +1329,13 @@
 				824717342BC9144F005E9631 /* ReportType.swift in Sources */,
 				82F7041F2C6DD29D00479206 /* TabType.swift in Sources */,
 				2CD2B5A72C771C3500E17B6A /* CommentUseCase.swift in Sources */,
+				2CD2B5A92C88753800E17B6A /* NetworkManager + Comment.swift in Sources */,
 				F3D452D52B8A647F000BA51C /* UINavigationController+Extension.swift in Sources */,
 				828715C02B9AC866001627DB /* AnswerRequest.swift in Sources */,
 				8295BDAA2BA04D1300115FA8 /* SignUpEmailView.swift in Sources */,
 				2C2E0ED52C63D177003928C1 /* CommentCell.swift in Sources */,
 				824717322BC9140A005E9631 /* ReportResponse.swift in Sources */,
+				2CD2B5AB2C88780D00E17B6A /* CommentResponse.swift in Sources */,
 				F3D452D92B8A7019000BA51C /* CustonNavigationBar.swift in Sources */,
 				825226EA2BA857FF006998E8 /* String+Extension.swift in Sources */,
 				823736AE2C6752E50057B9CF /* BulletinBoardSeeMoreSheetView.swift in Sources */,

--- a/Qapple/Qapple/Data/Network/DataMapping/ApiEndpoints.swift
+++ b/Qapple/Qapple/Data/Network/DataMapping/ApiEndpoints.swift
@@ -38,6 +38,11 @@ enum ApiEndpoints {
         
         // MARK: - 신고
         case report = "/reports"
+        
+        // MARK: - 댓글
+        case comments = "/boardComments"
+        case createComment = "/boardComments/board"
+        case likeComment = "/boardComments/heart"
     }
 }
 

--- a/Qapple/Qapple/Data/Network/DataMapping/Request/CommentRequest.swift
+++ b/Qapple/Qapple/Data/Network/DataMapping/Request/CommentRequest.swift
@@ -9,6 +9,8 @@ import Foundation
 
 
 class CommentRequest {
+    
+    // 댓글 생성 POST
     struct UploadComment {
         let boardId: Int
         let content: String

--- a/Qapple/Qapple/Data/Network/DataMapping/Request/CommentRequest.swift
+++ b/Qapple/Qapple/Data/Network/DataMapping/Request/CommentRequest.swift
@@ -1,0 +1,16 @@
+//
+//  CommentRequest.swift
+//  Qapple
+//
+//  Created by 문인범 on 9/4/24.
+//
+
+import Foundation
+
+
+class CommentRequest {
+    struct UploadComment {
+        let boardId: Int
+        let content: String
+    }
+}

--- a/Qapple/Qapple/Data/Network/DataMapping/Response/CommentResponse.swift
+++ b/Qapple/Qapple/Data/Network/DataMapping/Response/CommentResponse.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct CommentResponse: Codable {
     
-    
+    // 댓글 조회 Response
     struct Comments: Codable {
         let boardCommentInfos: [Comment]
         

--- a/Qapple/Qapple/Data/Network/DataMapping/Response/CommentResponse.swift
+++ b/Qapple/Qapple/Data/Network/DataMapping/Response/CommentResponse.swift
@@ -1,0 +1,35 @@
+//
+//  CommentResponse.swift
+//  Qapple
+//
+//  Created by 문인범 on 9/4/24.
+//
+
+import Foundation
+
+
+struct CommentResponse: Codable {
+    
+    
+    struct Comments: Codable {
+        let boardCommentInfos: [Comment]
+        
+        struct Comment: Codable, Identifiable {
+            var id: Int
+            var name: String
+            var content: String
+            var heartCount: Int
+            var isLiked: Bool
+            var createdAt: String
+            
+            enum CodingKeys: String, CodingKey {
+                case id = "boardCommentId"
+                case name = "writer"
+                case content
+                case heartCount
+                case isLiked
+                case createdAt
+            }
+        }
+    }
+}

--- a/Qapple/Qapple/Data/Network/NetworkManager + Comment.swift
+++ b/Qapple/Qapple/Data/Network/NetworkManager + Comment.swift
@@ -1,0 +1,132 @@
+//
+//  NetworkManager + Comment.swift
+//  Qapple
+//
+//  Created by 문인범 on 9/4/24.
+//
+
+import Foundation
+
+// MARK: - 댓글(Comment) 관련 API
+extension NetworkManager {
+    
+    
+    static func fetchComments(boardId: Int) async throws -> CommentResponse.Comments {
+        let urlString = ApiEndpoints.basicURLString(path: .comments)
+        
+        guard let url = URL(string: "\(urlString)/\(boardId)") else {
+            print("잘못된 URL 입니다! in CommentView")
+            throw NetworkError.cannotCreateURL
+        }
+        
+        var accessToken = ""
+        
+        do {
+            accessToken = try SignInInfo.shared.token(.access)
+        } catch {
+            print("액세스 토큰 반환 실패")
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                print(response)
+                throw NetworkError.badRequest
+            }
+            
+            let result = try JSONDecoder().decode(BaseResponse<CommentResponse.Comments>.self, from: data)
+            
+            print(result)
+            
+            return result.result
+        } catch {
+            print(String(describing: error))
+        }
+        
+        throw NetworkError.decodeFailed
+    }
+    
+    static func postComment(requestBody: CommentRequest.UploadComment) async throws {
+        let urlString = ApiEndpoints.basicURLString(path: .createComment)
+        
+        guard let url = URL(string: "\(urlString)/\(requestBody.boardId)") else {
+            print("잘못된 URL 입니다! in CommentView")
+            throw NetworkError.cannotCreateURL
+        }
+        
+        var accessToken = ""
+        
+        do {
+            accessToken = try SignInInfo.shared.token(.access)
+        } catch {
+            print("액세스 토큰 반환 실패")
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        
+        do {
+            let bodyText = requestBody.content
+            let body = try JSONEncoder().encode(bodyText)
+            
+            request.httpBody = body
+            
+            let (_, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                print(response)
+                throw NetworkError.badRequest
+            }
+        } catch {
+            print(String(describing: error))
+        }
+    }
+    
+    
+    
+    static func likeComment(commentId: Int) async throws {
+        let urlString = ApiEndpoints.basicURLString(path: .likeComment)
+        
+        guard let url = URL(string: "\(urlString)/\(commentId)") else {
+            print("잘못된 URL 입니다! in CommentView")
+            throw NetworkError.cannotCreateURL
+        }
+        
+        var accessToken = ""
+        
+        do {
+            accessToken = try SignInInfo.shared.token(.access)
+        } catch {
+            print("액세스 토큰 반환 실패")
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                print(response)
+                throw NetworkError.badRequest
+            }
+            
+        } catch {
+            print(String(describing: error))
+        }
+    }
+}

--- a/Qapple/Qapple/Data/Network/NetworkManager + Comment.swift
+++ b/Qapple/Qapple/Data/Network/NetworkManager + Comment.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - 댓글(Comment) 관련 API
 extension NetworkManager {
     
-    
+    // 해당 게시글에 댓글을 불러옵니다.
     static func fetchComments(boardId: Int) async throws -> CommentResponse.Comments {
         let urlString = ApiEndpoints.basicURLString(path: .comments)
         
@@ -43,7 +43,7 @@ extension NetworkManager {
             
             let result = try JSONDecoder().decode(BaseResponse<CommentResponse.Comments>.self, from: data)
             
-            print(result)
+//            print(result)
             
             return result.result
         } catch {
@@ -53,6 +53,7 @@ extension NetworkManager {
         throw NetworkError.decodeFailed
     }
     
+    // 댓글을 업로드 합니다.
     static func postComment(requestBody: CommentRequest.UploadComment) async throws {
         let urlString = ApiEndpoints.basicURLString(path: .createComment)
         
@@ -93,8 +94,7 @@ extension NetworkManager {
         }
     }
     
-    
-    
+    // 해당 댓글에 좋아요를 추가 or 취소 합니다.
     static func likeComment(commentId: Int) async throws {
         let urlString = ApiEndpoints.basicURLString(path: .likeComment)
         

--- a/Qapple/Qapple/Domain/Entity/Post.swift
+++ b/Qapple/Qapple/Domain/Entity/Post.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Post: Identifiable {
+struct Post: Identifiable, Hashable {
     let id = UUID()
     let anonymityIndex: Int
     let isMine: Bool

--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardCell.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardCell.swift
@@ -143,7 +143,7 @@ private struct RemoteView: View {
         
         var body: some View {
             Button {
-                pathModel.pushView(screen: BulletinBoardPathType.comment(postId: post.id))
+                pathModel.pushView(screen: BulletinBoardPathType.comment(post: post))
             } label: {
                 HStack(spacing: 4) {
                     Image(.comment)

--- a/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CommentCell: View {
-    let comment: ApiComment.Comment
+    let comment: CommentResponse.Comments.Comment
     
     let screenWidth: CGFloat = UIScreen.main.bounds.width
     let anchorWidth: CGFloat = 73

--- a/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
@@ -96,7 +96,8 @@ struct CommentCell: View {
                 Button {
                     // TODO: 댓글 좋아요 기능
                     Task.init {
-                        await commentUseCase.act(.like(id: 1))
+                        await commentUseCase.act(.like(id: comment.id))
+                        await commentUseCase.loadComments(boardId: 1)
                     }
                 } label: {
                     Image(systemName: comment.isLiked ? "heart.fill" : "heart")

--- a/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
@@ -17,7 +17,7 @@ struct CommentCell: View {
     @State private var anchor: CGFloat = 0
     @State private var isCellToggled: Bool = false
     
-    @ObservedObject var commentUseCase: CommentUseCase
+    @ObservedObject var commentViewModel: CommentViewModel
     
     var body: some View {
         HStack(spacing: 0) {
@@ -96,8 +96,8 @@ struct CommentCell: View {
                 Button {
                     // TODO: 댓글 좋아요 기능
                     Task.init {
-                        await commentUseCase.act(.like(id: comment.id))
-                        await commentUseCase.loadComments(boardId: 1)
+                        await commentViewModel.act(.like(id: comment.id))
+                        await commentViewModel.loadComments(boardId: 1)
                     }
                 } label: {
                     Image(systemName: comment.isLiked ? "heart.fill" : "heart")
@@ -125,7 +125,7 @@ struct CommentCell: View {
         Button {
             // TODO: 삭제 기능 구현
             Task.init {
-                await commentUseCase.act(.delete(id: 1))
+                await commentViewModel.act(.delete(id: 1))
             }
         } label: {
             ZStack {
@@ -145,7 +145,7 @@ struct CommentCell: View {
         Button {
             // TODO: 신고 기능 구현
             Task.init {
-                await commentUseCase.act(.report(id: 1))
+                await commentViewModel.act(.report(id: 1))
             }
         } label: {
             ZStack {

--- a/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CommentCell: View {
-    let comment: Comment
+    let comment: ApiComment.Comment
     
     let screenWidth: CGFloat = UIScreen.main.bounds.width
     let anchorWidth: CGFloat = 73
@@ -27,7 +27,7 @@ struct CommentCell: View {
             content
                 .frame(width: screenWidth)
             
-            if comment.isMine {
+            if comment.isLiked {
                 deleteBtn
             } else {
                 reportBtn
@@ -76,7 +76,7 @@ struct CommentCell: View {
                         .foregroundStyle(.icon)
                     
                     // 댓글 timestamp
-                    Text(comment.timestamp.timeAgo)
+                    Text(comment.createdAt)
                         .font(.pretendard(.light, size: 12))
                         .foregroundStyle(.disable)
                 }
@@ -97,16 +97,16 @@ struct CommentCell: View {
                     // TODO: 댓글 좋아요 기능
                     commentUseCase.act(.like(id: 1))
                 } label: {
-                    Image(systemName: comment.isLike ? "heart.fill" : "heart")
+                    Image(systemName: comment.isLiked ? "heart.fill" : "heart")
                         .resizable()
                         .scaledToFit()
                         .frame(width: 16)
-                        .foregroundStyle(comment.isLike ? .button : .sub4)
+                        .foregroundStyle(comment.isLiked ? .button : .sub4)
                 }
                 
                 // 댓글 좋아요 갯수
-                if comment.likeCount != 0 {
-                    Text("\(comment.likeCount)")
+                if comment.heartCount != 0 {
+                    Text("\(comment.heartCount)")
                         .font(.pretendard(.medium, size: 14))
                         .foregroundStyle(.sub3)
                 }
@@ -153,9 +153,9 @@ struct CommentCell: View {
     }
 }
 
-#Preview {
-    VStack {
-        CommentCell(comment: Comment(anonymityIndex: 1, isMine: false, isLike: true, likeCount: 12, content: "123123", timestamp: Date()), commentUseCase: .init())
-        CommentCell(comment: Comment(anonymityIndex: 2, isMine: true, isLike: false, likeCount: 0, content: "테스트", timestamp: Date().addingTimeInterval(-60*60*24)), commentUseCase: .init())
-    }
-}
+//#Preview {
+//    VStack {
+//        CommentCell(comment: Comment(anonymityIndex: 1, isMine: false, isLike: true, likeCount: 12, content: "123123", timestamp: Date()), commentUseCase: .init())
+//        CommentCell(comment: Comment(anonymityIndex: 2, isMine: true, isLike: false, likeCount: 0, content: "테스트", timestamp: Date().addingTimeInterval(-60*60*24)), commentUseCase: .init())
+//    }
+//}

--- a/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
@@ -95,7 +95,9 @@ struct CommentCell: View {
                 // 댓글 좋아요 버튼
                 Button {
                     // TODO: 댓글 좋아요 기능
-                    commentUseCase.act(.like(id: 1))
+                    Task.init {
+                        await commentUseCase.act(.like(id: 1))
+                    }
                 } label: {
                     Image(systemName: comment.isLiked ? "heart.fill" : "heart")
                         .resizable()
@@ -121,7 +123,9 @@ struct CommentCell: View {
     private var deleteBtn: some View {
         Button {
             // TODO: 삭제 기능 구현
-            commentUseCase.act(.delete(id: 1))
+            Task.init {
+                await commentUseCase.act(.delete(id: 1))
+            }
         } label: {
             ZStack {
                 Color.delete
@@ -139,7 +143,9 @@ struct CommentCell: View {
     private var reportBtn: some View {
         Button {
             // TODO: 신고 기능 구현
-            commentUseCase.act(.report(id: 1))
+            Task.init {
+                await commentUseCase.act(.report(id: 1))
+            }
         } label: {
             ZStack {
                 Color.report

--- a/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
@@ -8,26 +8,10 @@
 import SwiftUI
 
 final class CommentUseCase: ObservableObject {
-    @Published public var _state: State
-    
+
     @Published public var comments: [ApiComment.Comment] = []
     
     @MainActor
-    init() {
-        self._state = State(
-            post: Post(
-                anonymityIndex: 1,
-                isMine: false,
-                content: "지금 누가 팀이 있고 없는지 궁금해요",
-                isLike: true,
-                likeCount: 32,
-                commentCount: 32,
-                writingDate: Date().addingTimeInterval(-10)
-            ),
-            comment: sampleComments
-        )
-    }
-    
     func loadComments(boardId: Int) async {
         let urlString = ApiEndpoints.basicURLString(path: .comments)
         
@@ -105,15 +89,45 @@ final class CommentUseCase: ObservableObject {
             print(String(describing: error))
         }
     }
-}
+    
+    @MainActor
+    private func likeComment(commentId: Int) async {
+        let urlString = ApiEndpoints.basicURLString(path: .likeComment)
+        
+        guard let url = URL(string: "\(urlString)/\(commentId)") else {
+            print("잘못된 URL 입니다! in CommentView")
+            return
+        }
+        
+        var accessToken = ""
+        
+        do {
+            accessToken = try SignInInfo.shared.token(.access)
+        } catch {
+            print("액세스 토큰 반환 실패")
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
 
-
-extension CommentUseCase {
-    struct State {
-        let post: Post
-        let comment: [Comment]
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                print(response)
+                return
+            }
+            
+            
+        } catch {
+            
+        }
     }
 }
+
 
 extension CommentUseCase {
     enum Action {
@@ -138,6 +152,7 @@ extension CommentUseCase {
         case .like(id: let id):
             // TODO: 댓글 좋아요 기능 구현
             print("\(id)번째 댓글 좋아요")
+            await likeComment(commentId: id)
         }
     }
 }
@@ -179,13 +194,3 @@ struct ApiComment: Codable {
     
     
 }
-
-private let sampleComments: [Comment] = [
-    Comment(anonymityIndex: 1, isMine: false, isLike: false, likeCount: 10, content: "이말 완전 인정", timestamp: Date().addingTimeInterval(-60*60)),
-    Comment(anonymityIndex: 1, isMine: false, isLike: false, likeCount: 4, content: "22", timestamp: Date().addingTimeInterval(-60*58)),
-    Comment(anonymityIndex: 1, isMine: false, isLike: false, likeCount: 7, content: "나는 별로 안궁금한데?? 왜 이런거 궁금함? 난 이미 팀있지롱 ㅋ", timestamp: Date()),
-    Comment(anonymityIndex: 1, isMine: false, isLike: true, likeCount: 23, content: "와 위 댓글 ㅁㅊ네", timestamp: Date().addingTimeInterval(-900)),
-    Comment(anonymityIndex: 1, isMine: true, isLike: true, likeCount: 50, content: "왜 시비임? 현피ㄱ?", timestamp: Date().addingTimeInterval(-180)),
-    Comment(anonymityIndex: 1, isMine: false, isLike: true, likeCount: 83, content: "뜨던지ㅋ 목요일 오후 10시 지곡회관으로 와라", timestamp: Date().addingTimeInterval(-53)),
-    Comment(anonymityIndex: 1, isMine: true, isLike: true, likeCount: 125, content: "ㅋㅋ 한대 맞고 울지나 마라", timestamp: Date()),
-]

--- a/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
@@ -11,7 +11,7 @@ final class CommentUseCase: ObservableObject {
 
     @Published public var comments: [CommentResponse.Comments.Comment] = []
     
-    
+    // 댓글 불러오기
     @MainActor
     public func loadComments(boardId: Int) async {
         do {
@@ -22,6 +22,7 @@ final class CommentUseCase: ObservableObject {
         }
     }
     
+    // 댓글 좋아요 action
     @MainActor
     public func likeComment(commentId: Int) async {
         do {
@@ -31,6 +32,7 @@ final class CommentUseCase: ObservableObject {
         }
     }
     
+    // 댓글 달기 action
     @MainActor
     public func uploadComment(request: CommentRequest.UploadComment) async {
         do {

--- a/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
@@ -66,6 +66,45 @@ final class CommentUseCase: ObservableObject {
         }
         
     }
+    
+    private func postComment(boardId: Int, text: String) async {
+        let urlString = ApiEndpoints.basicURLString(path: .createComment)
+        
+        guard let url = URL(string: "\(urlString)/\(boardId)") else {
+            print("잘못된 URL 입니다! in CommentView")
+            return
+        }
+        
+        var accessToken = ""
+        
+        do {
+            accessToken = try SignInInfo.shared.token(.access)
+        } catch {
+            print("액세스 토큰 반환 실패")
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        do {
+            let bodyText = text
+            let body = try JSONEncoder().encode(bodyText)
+            
+            request.httpBody = body
+            
+            let (_, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                print(response)
+                return
+            }
+        } catch {
+            print(String(describing: error))
+        }
+    }
 }
 
 
@@ -78,17 +117,18 @@ extension CommentUseCase {
 
 extension CommentUseCase {
     enum Action {
-        case upload(content: String)
+        case upload(content: String, id: Int)
         case delete(id: Int)
         case report(id: Int)
         case like(id: Int)
     }
     
-    func act(_ action: Action) {
+    func act(_ action: Action) async {
         switch action {
-        case .upload(let content):
+        case .upload(let content, let id):
             // TODO: 댓글 업로드 기능 구현
             print("댓글 업로드: \(content)")
+            await postComment(boardId: id, text: content)
         case .delete(let id):
             // TODO: 댓글 삭제 기능 구현
             print("\(id)번째 댓글 삭제")

--- a/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentUseCase.swift
@@ -9,121 +9,34 @@ import SwiftUI
 
 final class CommentUseCase: ObservableObject {
 
-    @Published public var comments: [ApiComment.Comment] = []
+    @Published public var comments: [CommentResponse.Comments.Comment] = []
+    
     
     @MainActor
-    func loadComments(boardId: Int) async {
-        let urlString = ApiEndpoints.basicURLString(path: .comments)
-        
-        guard let url = URL(string: "\(urlString)/\(boardId)") else {
-            print("잘못된 URL 입니다! in CommentView")
-            return
-        }
-        
-        var accessToken = ""
-        
+    public func loadComments(boardId: Int) async {
         do {
-            accessToken = try SignInInfo.shared.token(.access)
+            let result = try await NetworkManager.fetchComments(boardId: boardId)
+            self.comments = result.boardCommentInfos
         } catch {
-            print("액세스 토큰 반환 실패")
-        }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                print(response)
-                return
-            }
-            
-            let result = try JSONDecoder().decode(BaseResponse<ApiComment>.self, from: data)
-            
-            self.comments = result.result.boardCommentInfos
-            print(self.comments)
-        } catch {
-            print(String(describing: error))
-        }
-        
-    }
-    
-    private func postComment(boardId: Int, text: String) async {
-        let urlString = ApiEndpoints.basicURLString(path: .createComment)
-        
-        guard let url = URL(string: "\(urlString)/\(boardId)") else {
-            print("잘못된 URL 입니다! in CommentView")
-            return
-        }
-        
-        var accessToken = ""
-        
-        do {
-            accessToken = try SignInInfo.shared.token(.access)
-        } catch {
-            print("액세스 토큰 반환 실패")
-        }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        
-        do {
-            let bodyText = text
-            let body = try JSONEncoder().encode(bodyText)
-            
-            request.httpBody = body
-            
-            let (_, response) = try await URLSession.shared.data(for: request)
-            
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                print(response)
-                return
-            }
-        } catch {
-            print(String(describing: error))
+            print(error.localizedDescription)
         }
     }
     
     @MainActor
-    private func likeComment(commentId: Int) async {
-        let urlString = ApiEndpoints.basicURLString(path: .likeComment)
-        
-        guard let url = URL(string: "\(urlString)/\(commentId)") else {
-            print("잘못된 URL 입니다! in CommentView")
-            return
-        }
-        
-        var accessToken = ""
-        
+    public func likeComment(commentId: Int) async {
         do {
-            accessToken = try SignInInfo.shared.token(.access)
+            _ = try await NetworkManager.likeComment(commentId: commentId)
         } catch {
-            print("액세스 토큰 반환 실패")
+            print(error.localizedDescription)
         }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "PATCH"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-
+    }
+    
+    @MainActor
+    public func uploadComment(request: CommentRequest.UploadComment) async {
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                print(response)
-                return
-            }
-            
-            
+            _ = try await NetworkManager.postComment(requestBody: request)
         } catch {
-            
+            print(error.localizedDescription)
         }
     }
 }
@@ -131,7 +44,7 @@ final class CommentUseCase: ObservableObject {
 
 extension CommentUseCase {
     enum Action {
-        case upload(content: String, id: Int)
+        case upload(request: CommentRequest.UploadComment)
         case delete(id: Int)
         case report(id: Int)
         case like(id: Int)
@@ -139,10 +52,10 @@ extension CommentUseCase {
     
     func act(_ action: Action) async {
         switch action {
-        case .upload(let content, let id):
+        case .upload(let request):
             // TODO: 댓글 업로드 기능 구현
-            print("댓글 업로드: \(content)")
-            await postComment(boardId: id, text: content)
+            print("댓글 업로드: \(request.content)")
+            await uploadComment(request: request)
         case .delete(let id):
             // TODO: 댓글 삭제 기능 구현
             print("\(id)번째 댓글 삭제")
@@ -153,44 +66,7 @@ extension CommentUseCase {
             // TODO: 댓글 좋아요 기능 구현
             print("\(id)번째 댓글 좋아요")
             await likeComment(commentId: id)
+            
         }
     }
-}
-
-
-struct Comment: Identifiable {
-    let id = UUID()
-    let anonymityIndex: Int
-    let isMine: Bool
-    let isLike: Bool
-    let likeCount: Int
-    let content: String
-    let timestamp: Date
-}
-
-
-
-struct ApiComment: Codable {
-    
-    let boardCommentInfos: [Comment]
-    
-    struct Comment: Codable, Identifiable {
-        var id: Int
-        var name: String
-        var content: String
-        var heartCount: Int
-        var isLiked: Bool
-        var createdAt: String
-        
-        enum CodingKeys: String, CodingKey {
-            case id = "boardCommentId"
-            case name = "writer"
-            case content
-            case heartCount
-            case isLiked
-            case createdAt
-        }
-    }
-    
-    
 }

--- a/Qapple/Qapple/Presentation/CommentView/CommentView.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentView.swift
@@ -68,7 +68,11 @@ struct CommentView: View {
             
             Button {
                 // TODO: 댓글 달기 기능 추가
-                commentUseCase.act(.upload(content: self.text))
+                Task.init {
+                    await commentUseCase.act(.upload(content: self.text, id: 1))
+                    await commentUseCase.loadComments(boardId: 1)
+                    self.text = ""
+                }
             } label: {
                 Image(systemName: "paperplane")
                     .resizable()

--- a/Qapple/Qapple/Presentation/CommentView/CommentView.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct CommentView: View {
     
-    @StateObject private var commentUseCase: CommentUseCase = .init()
+    @StateObject private var commentViewModel: CommentViewModel = .init()
     @State private var text: String = ""
     
     let post: Post
@@ -26,10 +26,10 @@ struct CommentView: View {
             ScrollView {
                 VStack(spacing: 0) {
                     // 데이터 연결
-                    ForEach(commentUseCase.comments) { comment in
+                    ForEach(commentViewModel.comments) { comment in
                         seperator
                         
-                        CommentCell(comment: comment, commentUseCase: commentUseCase)
+                        CommentCell(comment: comment, commentViewModel: commentViewModel)
                     }
                     
                     seperator
@@ -40,7 +40,7 @@ struct CommentView: View {
             .background(Color.bk)
             .refreshable {
                 Task.init {
-                    await commentUseCase.loadComments(boardId: 1)
+                    await commentViewModel.loadComments(boardId: 1)
                 }
             }
         }
@@ -53,7 +53,7 @@ struct CommentView: View {
         }
         .navigationBarBackButtonHidden()
         .task {
-            await commentUseCase.loadComments(boardId: 1)
+            await commentViewModel.loadComments(boardId: 1)
         }
     }
     
@@ -74,8 +74,8 @@ struct CommentView: View {
             Button {
                 // TODO: 댓글 달기 기능 추가
                 Task.init {
-                    await commentUseCase.act(.upload(request: .init(boardId: 1, content: self.text)))
-                    await commentUseCase.loadComments(boardId: 1)
+                    await commentViewModel.act(.upload(request: .init(boardId: 1, content: self.text)))
+                    await commentViewModel.loadComments(boardId: 1)
                     self.text = ""
                 }
             } label: {

--- a/Qapple/Qapple/Presentation/CommentView/CommentView.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentView.swift
@@ -74,7 +74,7 @@ struct CommentView: View {
             Button {
                 // TODO: 댓글 달기 기능 추가
                 Task.init {
-                    await commentUseCase.act(.upload(content: self.text, id: 1))
+                    await commentUseCase.act(.upload(request: .init(boardId: 1, content: self.text)))
                     await commentUseCase.loadComments(boardId: 1)
                     self.text = ""
                 }

--- a/Qapple/Qapple/Presentation/CommentView/CommentView.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentView.swift
@@ -12,7 +12,7 @@ struct CommentView: View {
     @StateObject private var commentUseCase: CommentUseCase = .init()
     @State private var text: String = ""
     
-    let postId: UUID
+    let post: Post
     
     private let screenWidth: CGFloat = UIScreen.main.bounds.width
     
@@ -20,7 +20,7 @@ struct CommentView: View {
         VStack(spacing: 0) {
             HeaderView()
             
-            BulletinBoardCell(post: commentUseCase._state.post, seeMoreAction: {})
+            BulletinBoardCell(post: self.post, seeMoreAction: {})
                 .frame(width: UIScreen.main.bounds.width)
             
             ScrollView {
@@ -117,6 +117,6 @@ private struct HeaderView: View {
     }
 }
 
-#Preview {
-    CommentView(postId: UUID())
-}
+//#Preview {
+//    CommentView(postId: UUID())
+//}

--- a/Qapple/Qapple/Presentation/CommentView/CommentView.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentView.swift
@@ -26,7 +26,7 @@ struct CommentView: View {
             ScrollView {
                 VStack(spacing: 0) {
                     // 데이터 연결
-                    ForEach(commentUseCase._state.comment) { comment in
+                    ForEach(commentUseCase.comments) { comment in
                         seperator
                         
                         CommentCell(comment: comment, commentUseCase: commentUseCase)
@@ -47,6 +47,9 @@ struct CommentView: View {
                 .frame(width: screenWidth)
         }
         .navigationBarBackButtonHidden()
+        .task {
+            await commentUseCase.loadComments(boardId: 1)
+        }
     }
     
     var seperator: some View {

--- a/Qapple/Qapple/Presentation/CommentView/CommentView.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentView.swift
@@ -38,6 +38,11 @@ struct CommentView: View {
                 }
             }
             .background(Color.bk)
+            .refreshable {
+                Task.init {
+                    await commentUseCase.loadComments(boardId: 1)
+                }
+            }
         }
         .onTapGesture {
             hideKeyboard()

--- a/Qapple/Qapple/Presentation/CommentView/CommentViewModel.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentViewModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-final class CommentUseCase: ObservableObject {
+final class CommentViewModel: ObservableObject {
 
     @Published public var comments: [CommentResponse.Comments.Comment] = []
     
@@ -44,7 +44,7 @@ final class CommentUseCase: ObservableObject {
 }
 
 
-extension CommentUseCase {
+extension CommentViewModel {
     enum Action {
         case upload(request: CommentRequest.UploadComment)
         case delete(id: Int)

--- a/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
+++ b/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
@@ -75,8 +75,8 @@ final class Router: ObservableObject, NavigationRouter {
                 NotificationListView()
             case .search:
                 BulletinSearchView()
-            case .comment(postId: let postId):
-                CommentView(postId: postId)
+            case .comment(post: let post):
+                CommentView(post: post)
                     .toolbar(.hidden, for: .tabBar)
             }
         } else if pathType == .myProfile {
@@ -141,7 +141,7 @@ enum BulletinBoardPathType: Hashable {
     case bulletinPosting
     case alert
     case search
-    case comment(postId: UUID)
+    case comment(post: Post)
 }
 
 /// 내 정보 Tab


### PR DESCRIPTION
## 변경 사항
- 댓글 View API 연결
- APIEndPoints 댓글 부분 추가
- NetworkManager + Comment 추가

## 테스트 결과
<img width="832" alt="스크린샷 2024-09-04 오후 9 16 49" src="https://github.com/user-attachments/assets/b7d0d63d-83b4-4f06-a46c-746fc46a07db">
<img width="512" alt="스크린샷 2024-09-04 오후 9 17 08" src="https://github.com/user-attachments/assets/2d11e377-0998-44db-99a8-e2338123ac53">
<img width="512" alt="스크린샷 2024-09-04 오후 9 17 20" src="https://github.com/user-attachments/assets/833dcdd1-898c-4bf5-8fdc-5f3a5671b837">


## 팀원 코멘트
* 현재 게시판과 댓글이 1:1로 연결되어 있지 않아 게시판 작업이 완료되면 추가로 연결 진행하겠습니다!
* Navigation을 통해 전달 받기 위해 Post 구조체에 Hashable를 추가했습니다.
* 삭제와 신고 기능은 아직 미구현인 상태여서 빼고 작업 완료했습니다.

close #181 