### PR TITLE
[Feat] BolletinBoard 화면 업데이트 관련

### DIFF
--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardUseCase.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardUseCase.swift
@@ -32,10 +32,6 @@ final class BulletinBoardUseCase: ObservableObject {
             endDate: calendar.date(from: endDateComponents)!, // TODO: 실제 값 업데이트
             posts: []
         )
-        
-        Task {
-            await fetchPostList()
-        }
     }
 }
 
@@ -47,7 +43,7 @@ extension BulletinBoardUseCase {
         let currentEvent: String
         let startDate: Date
         let endDate: Date
-        let posts: [Post]
+        var posts: [Post]
     }
 }
 
@@ -91,7 +87,7 @@ extension BulletinBoardUseCase {
 extension BulletinBoardUseCase {
     
     @MainActor
-    private func fetchPostList() {
+    func fetchPostList() {
         Task {
             let boardList = try await NetworkManager.fetchBoard()
             

--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardView.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardView.swift
@@ -35,12 +35,15 @@ struct BulletinBoardView: View {
                 }
                 .background(Background.first)
                 .refreshable {
-                    // TODO: 데이터 새로 불러오기
+                    bulletinBoardUseCase.effect(.fetchPost)
                 }
                 .navigationDestination(for: BulletinBoardPathType.self) { path in
                     pathModel.getNavigationDestination(view: path)
                         .environmentObject(bulletinBoardUseCase)
                 }
+            }
+            .onAppear{
+                bulletinBoardUseCase.effect(.fetchPost)
             }
         }
         .environmentObject(bulletinBoardUseCase)


### PR DESCRIPTION
## 변경 사항
- 게시글 올렸을 때 업데이트가 되도록 화면이 보일때마다 api 호출했습니다!


## 팀원 코멘트
| 
1. 수정이 필요할 수 있는 것 - 게시글의 정렬이 최신 것이 맨 위에 있어야할 것 같습니다!

2. 페이지네이션 기법으로 많은 양의 데이터를 처리하고 싶었는데 서버에서 한꺼번에 데이터가 들어와서 구현이 아직 안됩니다!
(+ 추가로 데이터가 그렇게 많지 않을 것 같아서 추후에 처리하면 될 것 같습니다)
