### PR TITLE
[Fix] 댓글뷰의 boardId와 게시글 id와 연결

### DIFF
--- a/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentCell.swift
@@ -19,6 +19,8 @@ struct CommentCell: View {
     
     @ObservedObject var commentViewModel: CommentViewModel
     
+    let post: Post
+    
     var body: some View {
         HStack(spacing: 0) {
             Spacer()
@@ -97,7 +99,7 @@ struct CommentCell: View {
                     // TODO: boardId 수정
                     Task.init {
                         await commentViewModel.act(.like(id: comment.id))
-                        await commentViewModel.loadComments(boardId: 1)
+                        await commentViewModel.loadComments(boardId: post.anonymityIndex)
                     }
                 } label: {
                     Image(systemName: comment.isLiked ? "heart.fill" : "heart")

--- a/Qapple/Qapple/Presentation/CommentView/CommentView.swift
+++ b/Qapple/Qapple/Presentation/CommentView/CommentView.swift
@@ -30,7 +30,7 @@ struct CommentView: View {
                         ForEach(commentViewModel.comments) { comment in
                             seperator
                             
-                            CommentCell(comment: comment, commentViewModel: commentViewModel)
+                            CommentCell(comment: comment, commentViewModel: commentViewModel, post: self.post)
                         }
                         
                         seperator
@@ -41,7 +41,7 @@ struct CommentView: View {
                 .background(Color.bk)
                 .refreshable {
                     Task.init {
-                        await commentViewModel.loadComments(boardId: 1)
+                        await commentViewModel.loadComments(boardId: post.anonymityIndex)
                     }
                 }
                 
@@ -60,7 +60,7 @@ struct CommentView: View {
         }
         .navigationBarBackButtonHidden()
         .task {
-            await commentViewModel.loadComments(boardId: 1)
+            await commentViewModel.loadComments(boardId: post.anonymityIndex)
         }
     }
     
@@ -81,8 +81,8 @@ struct CommentView: View {
             Button {
                 // TODO: 댓글 달기 기능 추가
                 Task.init {
-                    await commentViewModel.act(.upload(request: .init(boardId: 1, content: self.text)))
-                    await commentViewModel.loadComments(boardId: 1)
+                    await commentViewModel.act(.upload(request: .init(boardId: post.anonymityIndex, content: self.text)))
+                    await commentViewModel.loadComments(boardId: post.anonymityIndex)
                     self.text = ""
                 }
             } label: {


### PR DESCRIPTION
## 변경 사항
- 게시글 id와 CommentView의 id를 연결했습니다.

## 팀원 코멘트
| 

close #194 