### PR TITLE
[Fix] 댓글 여러번 눌리는 현상 해결

### DIFF
--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardCell.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardCell.swift
@@ -138,12 +138,17 @@ private struct RemoteView: View {
     
     struct CommentButton: View {
         @EnvironmentObject private var pathModel: Router
+        @EnvironmentObject private var bulletinBoardUseCase: BulletinBoardUseCase
         
         let post: Post
         
         var body: some View {
             Button {
-                pathModel.pushView(screen: BulletinBoardPathType.comment(post: post))
+                if !bulletinBoardUseCase.isClickComment {
+                    pathModel.pushView(screen: BulletinBoardPathType.comment(post: post))
+                    bulletinBoardUseCase.isClickComment = true
+                    print(bulletinBoardUseCase.isClickComment)
+                }
             } label: {
                 HStack(spacing: 4) {
                     Image(.comment)

--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardUseCase.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardUseCase.swift
@@ -9,6 +9,7 @@ import Foundation
 
 final class BulletinBoardUseCase: ObservableObject {
     @Published var _state: State
+    @Published var isClickComment: Bool = false
     
     init() {
         

--- a/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardView.swift
+++ b/Qapple/Qapple/Presentation/BulletinBoardView/BulletinBoardView.swift
@@ -42,6 +42,10 @@ struct BulletinBoardView: View {
                         .environmentObject(bulletinBoardUseCase)
                 }
             }
+            .onAppear{
+                bulletinBoardUseCase.isClickComment = false
+                print(bulletinBoardUseCase.isClickComment)
+            }
         }
         .environmentObject(bulletinBoardUseCase)
     }


### PR DESCRIPTION
## 변경 사항
- 댓글창으로 들어갔는데 댓글버튼이 활성화가 되어있어서 네비게이션이 중첩으로 쌓이는 것을 버튼 눌리지 않게 해결했습니다!

## 팀원 코멘트
| 아자아자 화이팅!!