### PR TITLE
[Feat] 알림 cell 버튼화

### DIFF
--- a/Qapple/Qapple/Domain/Entity/QappleNoti.swift
+++ b/Qapple/Qapple/Domain/Entity/QappleNoti.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct QappleNoti: Identifiable {
     let id = UUID()
+    let questionId: String
     let boardId: String
     let boardCommentId: String?
     let title: String

--- a/Qapple/Qapple/Presentation/AnswerView/View/AnswerView.swift
+++ b/Qapple/Qapple/Presentation/AnswerView/View/AnswerView.swift
@@ -52,7 +52,12 @@ struct AnswerView: View {
                             Task {
                                 do {
                                     try await viewModel.requestRegisterAnswer()
-                                    pathModel.pushView(screen: QuestionListPathType.completeAnswer)
+                                    if pathModel.searchPathType() == .questionList {
+                                        pathModel.pushView(screen: QuestionListPathType.completeAnswer)
+                                    } else if pathModel.searchPathType() == .bulletinBoard {
+                                        pathModel.pushView(screen: BulletinBoardPathType.completeAnswer)
+                                    }
+                                    
                                 } catch {
                                     isRegisterAnswerFailed.toggle()
                                 }

--- a/Qapple/Qapple/Presentation/AnswerView/View/AnswerView.swift
+++ b/Qapple/Qapple/Presentation/AnswerView/View/AnswerView.swift
@@ -52,9 +52,9 @@ struct AnswerView: View {
                             Task {
                                 do {
                                     try await viewModel.requestRegisterAnswer()
-                                    if pathModel.searchPathType() == .questionList {
+                                    if pathModel.searchPathType == .questionList {
                                         pathModel.pushView(screen: QuestionListPathType.completeAnswer)
-                                    } else if pathModel.searchPathType() == .bulletinBoard {
+                                    } else if pathModel.searchPathType == .bulletinBoard {
                                         pathModel.pushView(screen: BulletinBoardPathType.completeAnswer)
                                     }
                                     

--- a/Qapple/Qapple/Presentation/CompleteAnswerView/CompleteAnswerView.swift
+++ b/Qapple/Qapple/Presentation/CompleteAnswerView/CompleteAnswerView.swift
@@ -43,11 +43,19 @@ struct CompleteAnswerView: View {
             
             ActionButton("확인", isActive: .constant(true)) {
                 pathModel.popToRoot()
-                pathModel.pushView(
-                    screen: QuestionListPathType.todayAnswer(
-                        questionId: viewModel.questionId,
-                        questionContent: viewModel.questionContent)
-                )
+                if pathModel.searchPathType() == .questionList {
+                    pathModel.pushView(
+                        screen: QuestionListPathType.todayAnswer(
+                            questionId: viewModel.questionId,
+                            questionContent: viewModel.questionContent)
+                    )
+                } else if pathModel.searchPathType() == .bulletinBoard {
+                    pathModel.pushView(
+                        screen: BulletinBoardPathType.todayAnswer(
+                            questionId: viewModel.questionId,
+                            questionContent: viewModel.questionContent)
+                    )
+                }
                 viewModel.resetAnswerInfo()
             }
             .padding(.bottom, 16)

--- a/Qapple/Qapple/Presentation/CompleteAnswerView/CompleteAnswerView.swift
+++ b/Qapple/Qapple/Presentation/CompleteAnswerView/CompleteAnswerView.swift
@@ -43,13 +43,13 @@ struct CompleteAnswerView: View {
             
             ActionButton("확인", isActive: .constant(true)) {
                 pathModel.popToRoot()
-                if pathModel.searchPathType() == .questionList {
+                if pathModel.searchPathType == .questionList {
                     pathModel.pushView(
                         screen: QuestionListPathType.todayAnswer(
                             questionId: viewModel.questionId,
                             questionContent: viewModel.questionContent)
                     )
-                } else if pathModel.searchPathType() == .bulletinBoard {
+                } else if pathModel.searchPathType == .bulletinBoard {
                     pathModel.pushView(
                         screen: BulletinBoardPathType.todayAnswer(
                             questionId: viewModel.questionId,

--- a/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
+++ b/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
@@ -16,6 +16,16 @@ final class Router: ObservableObject, NavigationRouter {
     /// Tab 구분을 위한 타입 지정
     private var pathType: TabPathType
     
+    var searchPathType: TabPathType {
+        if pathType == .questionList {
+            return .questionList
+        } else if pathType == .bulletinBoard {
+            return .bulletinBoard
+        } else {
+            return .myProfile
+        }
+    }
+    
     /// path 추가
     func pushView<T: Hashable>(screen: T) {
         self.route.append(screen)
@@ -37,16 +47,6 @@ final class Router: ObservableObject, NavigationRouter {
     
     func updatePathType(to pathType: TabPathType) {
         self.pathType = pathType
-    }
-    
-    func searchPathType() -> TabPathType {
-        if pathType == .questionList {
-            return .questionList
-        } else if pathType == .bulletinBoard {
-            return .bulletinBoard
-        } else {
-            return .myProfile
-        }
     }
     
     @ViewBuilder

--- a/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
+++ b/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
@@ -69,6 +69,8 @@ final class Router: ObservableObject, NavigationRouter {
                 NotificationListView()
             case .todayAnswer(questionId: let questionId, questionContent: let questionContent):
                 AnswerListView(questionId: questionId, questionContent: questionContent)
+            case .todayQuestionList:
+                TodayQuestionListView()
             case .alert:
                 AlertView()
             case .comment(post: let post):
@@ -94,6 +96,18 @@ final class Router: ObservableObject, NavigationRouter {
                 CommentReportView(comment: comment)
             case .report(boardId: let boardId, isComment: let isComment):
                 ReportView(answerId: -1, boardId: boardId, isComment: isComment)
+            case .answer(let questionId, let questionContent):
+                AnswerView(
+                    viewModel: answerViewModel!,
+                    questionId: questionId,
+                    questionContent: questionContent
+                )
+            case .completeAnswer:
+                CompleteAnswerView(viewModel: answerViewModel!)
+            case .todayAnswer(questionId: let questionId, questionContent: let questionContent):
+                AnswerListView(questionId: questionId, questionContent: questionContent)
+            case .todayQuestionList:
+                TodayQuestionListView()
             }
         } else if pathType == .myProfile {
             let view = view as! MyProfilePathType
@@ -140,6 +154,7 @@ enum QuestionListPathType: Hashable {
     
     /// 모아보기
     case todayAnswer(questionId: Int, questionContent: String)
+    case todayQuestionList
     
     /// 알림 및 신고
     case notifications
@@ -158,6 +173,10 @@ enum BulletinBoardPathType: Hashable {
     case comment(post: Post)
     case commentReport(comment: CommentResponse.Comment)
     case report(boardId: Int, isComment: Bool)
+    case answer(questionId: Int, questionContent: String) // 답변하기
+    case completeAnswer // 답변 완료
+    case todayAnswer(questionId: Int, questionContent: String)
+    case todayQuestionList
 }
 
 /// 내 정보 Tab

--- a/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
+++ b/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
@@ -69,8 +69,6 @@ final class Router: ObservableObject, NavigationRouter {
                 NotificationListView()
             case .todayAnswer(questionId: let questionId, questionContent: let questionContent):
                 AnswerListView(questionId: questionId, questionContent: questionContent)
-            case .todayQuestionList:
-                TodayQuestionListView()
             case .alert:
                 AlertView()
             case .comment(post: let post):
@@ -106,8 +104,6 @@ final class Router: ObservableObject, NavigationRouter {
                 CompleteAnswerView(viewModel: answerViewModel!)
             case .todayAnswer(questionId: let questionId, questionContent: let questionContent):
                 AnswerListView(questionId: questionId, questionContent: questionContent)
-            case .todayQuestionList:
-                TodayQuestionListView()
             }
         } else if pathType == .myProfile {
             let view = view as! MyProfilePathType
@@ -154,7 +150,6 @@ enum QuestionListPathType: Hashable {
     
     /// 모아보기
     case todayAnswer(questionId: Int, questionContent: String)
-    case todayQuestionList
     
     /// 알림 및 신고
     case notifications
@@ -176,7 +171,6 @@ enum BulletinBoardPathType: Hashable {
     case answer(questionId: Int, questionContent: String) // 답변하기
     case completeAnswer // 답변 완료
     case todayAnswer(questionId: Int, questionContent: String)
-    case todayQuestionList
 }
 
 /// 내 정보 Tab

--- a/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
+++ b/Qapple/Qapple/Presentation/Helper/NavigationRouter.swift
@@ -39,6 +39,16 @@ final class Router: ObservableObject, NavigationRouter {
         self.pathType = pathType
     }
     
+    func searchPathType() -> TabPathType {
+        if pathType == .questionList {
+            return .questionList
+        } else if pathType == .bulletinBoard {
+            return .bulletinBoard
+        } else {
+            return .myProfile
+        }
+    }
+    
     @ViewBuilder
     public func getNavigationDestination(
         answerViewModel: AnswerViewModel? = nil,
@@ -61,6 +71,8 @@ final class Router: ObservableObject, NavigationRouter {
                 AnswerListView(questionId: questionId, questionContent: questionContent)
             case .alert:
                 AlertView()
+            case .comment(post: let post):
+                CommentView(post: post)
             case .report(answerId: let answerId, isComment: let isComment):
                 ReportView(answerId: answerId, boardId: -1, isComment: isComment)
             }
@@ -132,6 +144,7 @@ enum QuestionListPathType: Hashable {
     /// 알림 및 신고
     case notifications
     case alert
+    case comment(post: Post)
     case report(answerId: Int, isComment: Bool)
 }
 

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationCell.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationCell.swift
@@ -19,6 +19,7 @@ struct NotificationCell: View {
                 TitleView(notification: notification)
                 ContentView(notification: notification)
             }
+            .padding(.horizontal, 24)
         }
         .buttonStyle(PressableButtonStyle())
     }

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationCell.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationCell.swift
@@ -83,6 +83,7 @@ struct PressableButtonStyle: ButtonStyle {
 #Preview {
     NotificationCell(
         notification: .init(
+            questionId: "",
             boardId: "0",
             boardCommentId: "0",
             title: "누군가가 내 게시글에 좋아요 누름!",

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
@@ -69,9 +69,9 @@ private struct NotificationContentView: View {
                                             // 신고된 게시글이면 알림 표시
                                             isReportedPostTappedAlert.toggle()
                                         } else {
-                                            if pathModel.searchPathType() == .questionList {
+                                            if pathModel.searchPathType == .questionList {
                                                 pathModel.pushView(screen: QuestionListPathType.comment(post: post))
-                                            } else if pathModel.searchPathType() == .bulletinBoard {
+                                            } else if pathModel.searchPathType == .bulletinBoard {
                                                 pathModel.pushView(screen: BulletinBoardPathType.comment(post: post))
                                             }
                                         }
@@ -83,16 +83,16 @@ private struct NotificationContentView: View {
                                         if let question = viewModel.questions.first(where: { $0.questionId == questionId }) {
                                             if question.isAnswered {
                                                 // 답변된 경우 answerListView로 이동
-                                                if pathModel.searchPathType() == .questionList {
+                                                if pathModel.searchPathType == .questionList {
                                                     pathModel.pushView(screen: QuestionListPathType.todayAnswer(questionId: question.questionId, questionContent: question.content))
-                                                } else if pathModel.searchPathType() == .bulletinBoard {
+                                                } else if pathModel.searchPathType == .bulletinBoard {
                                                     pathModel.pushView(screen: BulletinBoardPathType.todayAnswer(questionId: question.questionId, questionContent: question.content))
                                                 }
                                             } else {
                                                 // 답변되지 않은 경우 answerView로 이동
-                                                if pathModel.searchPathType() == .questionList {
+                                                if pathModel.searchPathType == .questionList {
                                                     pathModel.pushView(screen: QuestionListPathType.answer(questionId: question.questionId, questionContent: question.content))
-                                                } else if pathModel.searchPathType() == .bulletinBoard {
+                                                } else if pathModel.searchPathType == .bulletinBoard {
                                                     pathModel.pushView(screen: BulletinBoardPathType.answer(questionId: question.questionId, questionContent: question.content))
                                                 }
                                             }

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
@@ -78,27 +78,25 @@ private struct NotificationContentView: View {
                                     }
                                 }
                             } else {
-                                Task {
-                                    // notification의 content와 QuestionViewModel의 content를 비교
-                                    if let question = viewModel.questions.first(where: { $0.content == notification.content }) {
-                                        
-                                        if question.isAnswered {
-                                            // 답변된 경우 answerListView로 이동
-                                            if pathModel.searchPathType() == .questionList {
-                                                pathModel.pushView(screen: QuestionListPathType.todayAnswer(questionId: question.questionId, questionContent: question.content))
-                                            } else if pathModel.searchPathType() == .bulletinBoard {
-                                                pathModel.pushView(screen: BulletinBoardPathType.todayAnswer(questionId: question.questionId, questionContent: question.content))
-                                            }
-                                        } else {
-                                            // 답변되지 않은 경우 answerView로 이동
-                                            if pathModel.searchPathType() == .questionList {
-                                                pathModel.pushView(screen: QuestionListPathType.answer(questionId: question.questionId, questionContent: question.content))
-                                            } else if pathModel.searchPathType() == .bulletinBoard {
-                                                pathModel.pushView(screen: BulletinBoardPathType.answer(questionId: question.questionId, questionContent: question.content))
+                                if let questionId = Int(notification.questionId) {
+                                    Task {
+                                        if let question = viewModel.questions.first(where: { $0.questionId == questionId }) {
+                                            if question.isAnswered {
+                                                // 답변된 경우 answerListView로 이동
+                                                if pathModel.searchPathType() == .questionList {
+                                                    pathModel.pushView(screen: QuestionListPathType.todayAnswer(questionId: question.questionId, questionContent: question.content))
+                                                } else if pathModel.searchPathType() == .bulletinBoard {
+                                                    pathModel.pushView(screen: BulletinBoardPathType.todayAnswer(questionId: question.questionId, questionContent: question.content))
+                                                }
+                                            } else {
+                                                // 답변되지 않은 경우 answerView로 이동
+                                                if pathModel.searchPathType() == .questionList {
+                                                    pathModel.pushView(screen: QuestionListPathType.answer(questionId: question.questionId, questionContent: question.content))
+                                                } else if pathModel.searchPathType() == .bulletinBoard {
+                                                    pathModel.pushView(screen: BulletinBoardPathType.answer(questionId: question.questionId, questionContent: question.content))
+                                                }
                                             }
                                         }
-                                    } else {
-                                        print("해당 질문을 찾을 수 없습니다.")
                                     }
                                 }
                             }

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
@@ -36,6 +36,9 @@ private struct NotificationContentView: View {
     
     @EnvironmentObject private var pathModel: Router
     @EnvironmentObject private var notificationUseCase: NotificationUseCase
+    @EnvironmentObject private var bulletinBoardUseCase: BulletinBoardUseCase
+    
+    @State private var isReportedPostTappedAlert = false // 신고된 게시글 알림
     
     var body: some View {
         VStack(spacing: 0) {
@@ -56,7 +59,25 @@ private struct NotificationContentView: View {
                     ForEach(Array(notificationUseCase.state.notificationList.enumerated()), id: \.offset) { index, notification in
                         
                         NotificationCell(notification: notification) {
-                            // TODO: 네비게이션 지정 or 버튼 제거
+                            print(pathModel.searchPathType())
+                            if let boardId = Int(notification.boardId) {
+                                Task {
+                                    if let post = bulletinBoardUseCase.state.posts.first(where: { $0.boardId == boardId }) {
+                                        if post.isReported {
+                                            // 신고된 게시글이면 알림 표시
+                                            isReportedPostTappedAlert.toggle()
+                                        } else {
+                                            if pathModel.searchPathType() == .questionList {
+                                                pathModel.pushView(screen: QuestionListPathType.comment(post: post))
+                                            } else if pathModel.searchPathType() == .bulletinBoard {
+                                                pathModel.pushView(screen: BulletinBoardPathType.comment(post: post))
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                // TODO: 질문 리스트로 가기
+                            }
                         }
                         .onAppear {
                             if index == notificationUseCase.state.notificationList.count - 1
@@ -79,6 +100,14 @@ private struct NotificationContentView: View {
             .refreshable {
                 notificationUseCase.refreshNotificationList()
             }
+            .alert("신고된 게시글", isPresented: $isReportedPostTappedAlert) {
+                Button("확인", role: .none, action: {})
+            } message: {
+                Text("신고된 게시글은 열람할 수 없습니다.")
+            }
+        }
+        .onAppear {
+            bulletinBoardUseCase.effect(.fetchPost)
         }
     }
 }

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
@@ -60,6 +60,7 @@ private struct NotificationContentView: View {
                         
                         NotificationCell(notification: notification) {
                             if let boardId = Int(notification.boardId) {
+                                // 게시글 댓글로 이동
                                 Task {
                                     if let post = bulletinBoardUseCase.state.posts.first(where: { $0.boardId == boardId }) {
                                         if post.isReported {
@@ -75,6 +76,7 @@ private struct NotificationContentView: View {
                                     }
                                 }
                             } else {
+                                // 질문리스트로 이동
                                 if pathModel.searchPathType() == .questionList {
                                     pathModel.pushView(screen: QuestionListPathType.todayQuestionList)
                                 } else if pathModel.searchPathType() == .bulletinBoard {

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
@@ -100,7 +100,6 @@ private struct NotificationContentView: View {
                         .foregroundStyle(TextLabel.sub4)
                         .padding(.top, 16)
                 }
-                .padding(.horizontal, 24)
             }
             .refreshable {
                 notificationUseCase.refreshNotificationList()
@@ -121,4 +120,6 @@ private struct NotificationContentView: View {
 
 #Preview {
     NotificationListView()
+        .environmentObject(NotificationUseCase())
+        .environmentObject(BulletinBoardUseCase())
 }

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationListView.swift
@@ -59,7 +59,6 @@ private struct NotificationContentView: View {
                     ForEach(Array(notificationUseCase.state.notificationList.enumerated()), id: \.offset) { index, notification in
                         
                         NotificationCell(notification: notification) {
-                            print(pathModel.searchPathType())
                             if let boardId = Int(notification.boardId) {
                                 Task {
                                     if let post = bulletinBoardUseCase.state.posts.first(where: { $0.boardId == boardId }) {
@@ -76,7 +75,11 @@ private struct NotificationContentView: View {
                                     }
                                 }
                             } else {
-                                // TODO: 질문 리스트로 가기
+                                if pathModel.searchPathType() == .questionList {
+                                    pathModel.pushView(screen: QuestionListPathType.todayQuestionList)
+                                } else if pathModel.searchPathType() == .bulletinBoard {
+                                    pathModel.pushView(screen: BulletinBoardPathType.todayQuestionList)
+                                }
                             }
                         }
                         .onAppear {

--- a/Qapple/Qapple/Presentation/NotificationView/NotificationUseCase.swift
+++ b/Qapple/Qapple/Presentation/NotificationView/NotificationUseCase.swift
@@ -51,6 +51,7 @@ extension NotificationUseCase {
                 
                 state.notificationList += response.content.map {
                     QappleNoti(
+                        questionId: $0.questionId ?? "",
                         boardId: $0.boardId ?? "",
                         boardCommentId: $0.boardCommentId,
                         title: $0.title,
@@ -90,6 +91,7 @@ extension NotificationUseCase {
                 state.notificationList.removeAll()
                 state.notificationList += notificationList.content.map {
                     QappleNoti(
+                        questionId: $0.questionId ?? "",
                         boardId: $0.boardId ?? "",
                         boardCommentId: $0.boardCommentId,
                         title: $0.title,

--- a/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
+++ b/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
@@ -116,7 +116,10 @@ private struct MainTabView: View {
                 )
             }
             .navigationDestination(for: BulletinBoardPathType.self) { path in
-                activePathModel.getNavigationDestination(view: path)
+                activePathModel.getNavigationDestination(
+                    answerViewModel: answerViewModel,
+                    view: path
+                )
             }
             .navigationDestination(for: MyProfilePathType.self) { path in
                 activePathModel.getNavigationDestination(view: path)

--- a/Qapple/Qapple/Presentation/TodayQuestionListView/View/QuestionCell.swift
+++ b/Qapple/Qapple/Presentation/TodayQuestionListView/View/QuestionCell.swift
@@ -146,12 +146,22 @@ private struct AnswerButtonView: View {
         HStack(alignment: .top, spacing: 8) {
             Spacer()
             Button {
-                pathModel.pushView(
-                    screen: QuestionListPathType.answer(
-                        questionId: question.questionId,
-                        questionContent: question.content
+                if pathModel.searchPathType() == .questionList {
+                    pathModel.pushView(
+                        screen: QuestionListPathType.answer(
+                            questionId: question.questionId,
+                            questionContent: question.content
+                        )
                     )
-                )
+                } else if pathModel.searchPathType() == .bulletinBoard {
+                    pathModel.pushView(
+                        screen: BulletinBoardPathType.answer(
+                            questionId: question.questionId,
+                            questionContent: question.content
+                        )
+                    )
+                }
+                
             } label: {
                 Text(question.isAnswered ? "답변완료" : "답변하기")
                     .font(.pretendard(question.isAnswered ? .medium : .semiBold, size: 14))

--- a/Qapple/Qapple/Presentation/TodayQuestionListView/View/QuestionCell.swift
+++ b/Qapple/Qapple/Presentation/TodayQuestionListView/View/QuestionCell.swift
@@ -146,14 +146,14 @@ private struct AnswerButtonView: View {
         HStack(alignment: .top, spacing: 8) {
             Spacer()
             Button {
-                if pathModel.searchPathType() == .questionList {
+                if pathModel.searchPathType == .questionList {
                     pathModel.pushView(
                         screen: QuestionListPathType.answer(
                             questionId: question.questionId,
                             questionContent: question.content
                         )
                     )
-                } else if pathModel.searchPathType() == .bulletinBoard {
+                } else if pathModel.searchPathType == .bulletinBoard {
                     pathModel.pushView(
                         screen: BulletinBoardPathType.answer(
                             questionId: question.questionId,

--- a/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
+++ b/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
@@ -13,6 +13,24 @@ struct TodayQuestionListView: View {
                 .edgesIgnoringSafeArea(.all)
             
             VStack(spacing: 0) {
+                if !pathModel.route.isEmpty {
+                    CustomNavigationBar(
+                        leadingView: {
+                            CustomNavigationBackButton(buttonType: .arrow) {
+                                pathModel.pop()
+                            }
+                        },
+                        principalView: {
+                            Text("질문 리스트")
+                                .font(.pretendard(.semiBold, size: 17))
+                        },
+                        trailingView: {
+                            
+                        },
+                        backgroundColor: Color.Background.first
+                    )
+                }
+                
                 QuestionListView(viewModel: viewModel, isBottomSheetPresented: $isBottomSheetPresented)
                 
                 Spacer()
@@ -92,13 +110,24 @@ struct TodayQuestionListView: View {
                                         return
                                     }
                                     
-                                    pathModel.pushView(
-                                        screen: QuestionListPathType.todayAnswer(
-                                            questionId: id, questionContent: viewModel.contentForQuestion(
-                                                withId: id
-                                            ) ?? "내용 없음"
+                                    if pathModel.searchPathType() == .questionList {
+                                        pathModel.pushView(
+                                            screen: QuestionListPathType.todayAnswer(
+                                                questionId: id, questionContent: viewModel.contentForQuestion(
+                                                    withId: id
+                                                ) ?? "내용 없음"
+                                            )
                                         )
-                                    )
+                                    } else if pathModel.searchPathType() == .bulletinBoard {
+                                        pathModel.pushView(
+                                            screen: BulletinBoardPathType.todayAnswer(
+                                                questionId: id, questionContent: viewModel.contentForQuestion(
+                                                    withId: id
+                                                ) ?? "내용 없음"
+                                            )
+                                        )
+                                    }
+                                    
                                 }
                                 .alert("답변하면 확인이 가능해요 😀", isPresented: $isAnsweredAlert) {
                                     Button("확인", role: .none) {}

--- a/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
+++ b/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
@@ -13,10 +13,6 @@ struct TodayQuestionListView: View {
                 .edgesIgnoringSafeArea(.all)
             
             VStack(spacing: 0) {
-                if !pathModel.route.isEmpty {
-                    HeaderView()
-                }
-                
                 QuestionListView(viewModel: viewModel, isBottomSheetPresented: $isBottomSheetPresented)
                 
                 Spacer()
@@ -34,29 +30,6 @@ struct TodayQuestionListView: View {
             Task {
                 await viewModel.refreshGetQuestions()
             }
-        }
-    }
-    // MARK: - HeaderView
-    
-    private struct HeaderView: View {
-        
-        @EnvironmentObject private var pathModel: Router
-        
-        var body: some View {
-            CustomNavigationBar(
-                leadingView: {
-                    CustomNavigationBackButton(buttonType: .arrow) {
-                        pathModel.pop()
-                    }
-                },
-                principalView: {
-                    Text("질문 리스트")
-                        .font(.pretendard(.semiBold, size: 17))
-                },
-                trailingView: {
-                    
-                },
-                backgroundColor: Color.Background.first)
         }
     }
     

--- a/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
+++ b/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
@@ -92,7 +92,7 @@ struct TodayQuestionListView: View {
                                         return
                                     }
                                     
-                                    if pathModel.searchPathType() == .questionList {
+                                    if pathModel.searchPathType == .questionList {
                                         pathModel.pushView(
                                             screen: QuestionListPathType.todayAnswer(
                                                 questionId: id, questionContent: viewModel.contentForQuestion(
@@ -100,7 +100,7 @@ struct TodayQuestionListView: View {
                                                 ) ?? "내용 없음"
                                             )
                                         )
-                                    } else if pathModel.searchPathType() == .bulletinBoard {
+                                    } else if pathModel.searchPathType == .bulletinBoard {
                                         pathModel.pushView(
                                             screen: BulletinBoardPathType.todayAnswer(
                                                 questionId: id, questionContent: viewModel.contentForQuestion(

--- a/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
+++ b/Qapple/Qapple/Presentation/TodayQuestionListView/View/TodayQuestionListView.swift
@@ -14,21 +14,7 @@ struct TodayQuestionListView: View {
             
             VStack(spacing: 0) {
                 if !pathModel.route.isEmpty {
-                    CustomNavigationBar(
-                        leadingView: {
-                            CustomNavigationBackButton(buttonType: .arrow) {
-                                pathModel.pop()
-                            }
-                        },
-                        principalView: {
-                            Text("질문 리스트")
-                                .font(.pretendard(.semiBold, size: 17))
-                        },
-                        trailingView: {
-                            
-                        },
-                        backgroundColor: Color.Background.first
-                    )
+                    HeaderView()
                 }
                 
                 QuestionListView(viewModel: viewModel, isBottomSheetPresented: $isBottomSheetPresented)
@@ -48,6 +34,29 @@ struct TodayQuestionListView: View {
             Task {
                 await viewModel.refreshGetQuestions()
             }
+        }
+    }
+    // MARK: - HeaderView
+    
+    private struct HeaderView: View {
+        
+        @EnvironmentObject private var pathModel: Router
+        
+        var body: some View {
+            CustomNavigationBar(
+                leadingView: {
+                    CustomNavigationBackButton(buttonType: .arrow) {
+                        pathModel.pop()
+                    }
+                },
+                principalView: {
+                    Text("질문 리스트")
+                        .font(.pretendard(.semiBold, size: 17))
+                },
+                trailingView: {
+                    
+                },
+                backgroundColor: Color.Background.first)
         }
     }
     


### PR DESCRIPTION
## 변경 사항
- 게시물 알림 클릭 시 해당 commentView로 이동
- 오늘의 질문 알림 클릭 시 질문리스트(QuestionListView)로 이동

## 팀원 코멘트
| 알림 버튼이 오늘의 질문(QuestionListPathType)과 게시판(BulletinBoardPathType) 탭바 2곳에 있다보니까 NavigationRouter파일을 많이 수정했습니다..! 해당 TabPathType에서 알림을 타고 들어가서 이동해야해서..
(다른 방법은 생각이 안나는.... Router에 있는 updatePathType 함수도 써보려고 막 했는데 아쉽게도..)
그래서 조건문이 많이 생겼는데 다른 의견(방법)이 있다면 공유하면 좋을 것 같아요!