### PR TITLE
[Feat] 푸시 알림 관련 인터랙션 추가

### DIFF
--- a/Qapple/Qapple.xcodeproj/project.pbxproj
+++ b/Qapple/Qapple.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2C1E27232C71AC0C000B9D86 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1E27222C71AC0C000B9D86 /* NavigationRouter.swift */; };
 		2C2E0ED52C63D177003928C1 /* CommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2E0ED42C63D177003928C1 /* CommentCell.swift */; };
 		2C2E0ED72C646EC9003928C1 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2E0ED62C646EC9003928C1 /* CommentView.swift */; };
+		2C7AE7AD2CB96865004098AF /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7AE7AC2CB96865004098AF /* PushNotificationManager.swift */; };
 		2CD2B5A52C77192600E17B6A /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A42C77192600E17B6A /* Pretendard-Light.otf */; };
 		2CD2B5A72C771C3500E17B6A /* CommentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A62C771C3500E17B6A /* CommentViewModel.swift */; };
 		2CD2B5A92C88753800E17B6A /* NetworkManager+Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2B5A82C88753800E17B6A /* NetworkManager+Comment.swift */; };
@@ -203,6 +204,7 @@
 		2C1E27222C71AC0C000B9D86 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
 		2C2E0ED42C63D177003928C1 /* CommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCell.swift; sourceTree = "<group>"; };
 		2C2E0ED62C646EC9003928C1 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
+		2C7AE7AC2CB96865004098AF /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
 		2CD2B5A42C77192600E17B6A /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		2CD2B5A62C771C3500E17B6A /* CommentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentViewModel.swift; sourceTree = "<group>"; };
 		2CD2B5A82C88753800E17B6A /* NetworkManager+Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkManager+Comment.swift"; sourceTree = "<group>"; };
@@ -676,6 +678,7 @@
 				828A03DA2BAB36F80038CF91 /* NotificationManager.swift */,
 				82CDA7762BB2EBC00031AEB4 /* PopGestureManager.swift */,
 				82CDA7782BB2EBCF0031AEB4 /* HapticManager.swift */,
+				2C7AE7AC2CB96865004098AF /* PushNotificationManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -1328,6 +1331,7 @@
 				074819002B8F3DDE00380F14 /* SeeMoreView.swift in Sources */,
 				073C3DE22B871F130016C333 /* TimeInterval+Extension.swift in Sources */,
 				824717342BC9144F005E9631 /* ReportType.swift in Sources */,
+				2C7AE7AD2CB96865004098AF /* PushNotificationManager.swift in Sources */,
 				82F7041F2C6DD29D00479206 /* TabType.swift in Sources */,
 				8271691D2C9EB95000D8BF81 /* NotificationResponse.swift in Sources */,
 				2CD2B5A72C771C3500E17B6A /* CommentViewModel.swift in Sources */,

--- a/Qapple/Qapple/App/AppDelegate.swift
+++ b/Qapple/Qapple/App/AppDelegate.swift
@@ -135,4 +135,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
     completionHandler()
   }
+    
+    // 앱이 종료된 상태에서 push 알림을 눌렀을 때
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        
+        print(#function)
+        if let questionId = userInfo["questionId"] {
+            let idString = questionId as! String
+            PushNotificationManager.shared.questionId = Int(idString)
+        }
+        
+        if let boardId = userInfo["boardId"] {
+            let idString = boardId as! String
+            PushNotificationManager.shared.boardId = Int(idString)
+        }
+        
+        completionHandler(.newData)
+    }
 }

--- a/Qapple/Qapple/App/AppDelegate.swift
+++ b/Qapple/Qapple/App/AppDelegate.swift
@@ -120,6 +120,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     if let messageID = userInfo[gcmMessageIDKey] {
         print("Message ID: \(messageID)")
     }
+    
+    if let questionId = userInfo["questionId"] {
+        let idString = questionId as! String
+        
+    }
+      
+    if let boardId = userInfo["boardId"] {
+        let idString = boardId as! String
+        PushNotificationManager.shared.boardId = Int(idString)
+    }
       
     print(userInfo)
 

--- a/Qapple/Qapple/App/AppDelegate.swift
+++ b/Qapple/Qapple/App/AppDelegate.swift
@@ -90,7 +90,7 @@ extension AppDelegate: MessagingDelegate{
 @available(iOS 10, *)
 extension AppDelegate: UNUserNotificationCenterDelegate {
   
-    // 푸시 메세지가 앱이 켜져있을 때 나올떄
+    // 푸시 메세지가 앱이 켜져있을 때 나올 때
   func userNotificationCenter(_ center: UNUserNotificationCenter,
                               willPresent notification: UNNotification,
                               withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions)
@@ -110,7 +110,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     completionHandler([[.banner, .badge, .sound]])
   }
 
-    // 푸시메세지를 받았을 떄
+    // 푸시메세지를 받았을 때
   func userNotificationCenter(_ center: UNUserNotificationCenter,
                               didReceive response: UNNotificationResponse,
                               withCompletionHandler completionHandler: @escaping () -> Void) {
@@ -123,7 +123,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     
     if let questionId = userInfo["questionId"] {
         let idString = questionId as! String
-        
+        PushNotificationManager.shared.questionId = Int(idString)
     }
       
     if let boardId = userInfo["boardId"] {

--- a/Qapple/Qapple/Presentation/Manager/PushNotificationManager.swift
+++ b/Qapple/Qapple/Presentation/Manager/PushNotificationManager.swift
@@ -1,0 +1,17 @@
+//
+//  PushNotificationManager.swift
+//  Qapple
+//
+//  Created by 문인범 on 10/11/24.
+//
+
+import Foundation
+
+
+final class PushNotificationManager: ObservableObject {
+    static let shared = PushNotificationManager()
+    @Published var boardId: Int?
+    @Published var questionId: Int?
+    
+    private init() {}
+}

--- a/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
+++ b/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
@@ -163,6 +163,7 @@ private struct MainTabView: View {
             }
             
             self.tabType = .questionList
+            self.pushNotificationManager.questionId = nil
         }
     }
 }

--- a/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
+++ b/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
@@ -158,12 +158,11 @@ private struct MainTabView: View {
             }
         }
         .onReceive(self.pushNotificationManager.$questionId) { id in
-            guard let questionId = id else {
+            guard let _ = id else {
                 return
             }
             
             self.tabType = .questionList
-            
         }
     }
 }

--- a/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
+++ b/Qapple/Qapple/Presentation/SignInView/View/MainView.swift
@@ -141,10 +141,29 @@ private struct MainTabView: View {
             Task.init {
                 let singleBoard = try await NetworkManager.fetchSingleBoard(.init(boardId: boardId))
                 
-                let post = Post(boardId: singleBoard.boardId, writerId: singleBoard.writerId, writerNickname: singleBoard.writerNickname, content: singleBoard.content, heartCount: singleBoard.heartCount, commentCount: singleBoard.commentCount, createAt: singleBoard.createdAt.ISO8601ToDate, isMine: singleBoard.isMine, isReported: singleBoard.isReported, isLiked: singleBoard.isLiked)
+                let post = Post(
+                    boardId: singleBoard.boardId,
+                    writerId: singleBoard.writerId,
+                    writerNickname: singleBoard.writerNickname,
+                    content: singleBoard.content,
+                    heartCount: singleBoard.heartCount,
+                    commentCount: singleBoard.commentCount,
+                    createAt: singleBoard.createdAt.ISO8601ToDate,
+                    isMine: singleBoard.isMine,
+                    isReported: singleBoard.isReported,
+                    isLiked: singleBoard.isLiked)
                 
                 self.activePathModel.pushView(screen: BulletinBoardPathType.comment(post: post))
+                self.pushNotificationManager.boardId = nil
             }
+        }
+        .onReceive(self.pushNotificationManager.$questionId) { id in
+            guard let questionId = id else {
+                return
+            }
+            
+            self.tabType = .questionList
+            
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
- 푸시 알림을 눌렀을 때 특정 뷰로 네비게이팅
    - 댓글 관련 알림일 경우 CommentView로 바로 네비게이팅
    - 질문 관련 알림일 경우 HomeView로 네비게이팅

## 팀원 코멘트
| 질문 관련 알림을 터치할 때 HomeView의 questionList로 보내고 싶은데 내부 프로퍼티라서 어떻게 해야 할지 모르겠어서 일단 HomeView로 가게 했습니다.
QuestionListView로 가는게 맞다 하면 밖으로 빼서 다시 작업할게요!

close #249 