### PR TITLE
[Feat] Notification뷰 네비게이션 적용

### DIFF
--- a/Qapple/Qapple/SourceCode/Data/Repository/NotificationRepository.swift
+++ b/Qapple/Qapple/SourceCode/Data/Repository/NotificationRepository.swift
@@ -15,7 +15,7 @@ import ComposableArchitecture
 struct NotificationRepository {
     var fetchNotificationList: (_ threshold: Int?) async throws -> ([QappleNotification], QappleAPI.PaginationInfo)
     var fetchSingleBoard: (_ boardId: Int) async throws -> BulletinBoard
-    var isAnsweredQuestion: (_ questionId: Int) async throws -> Bool
+    var isAnsweredQuestion: (_ questionId: Int) async throws -> (Bool, Question)
     
     private static let dummyNoti: [QappleNotification] = {
         var result = [QappleNotification]()
@@ -64,8 +64,17 @@ extension NotificationRepository: DependencyKey {
         isAnsweredQuestion: { questionId in
             let url = try QappleAPI.Answer.listOfProfile(threshold: nil, pageSize: 100).url()
             let response: BaseResponse<AnswersOfProfileDTO> = try await NetworkService.shared.get(url: url)
-            let result = response.result.content.contains{ $0.questionId == questionId }
-            return result
+            let isAnswered = response.result.content.contains{ $0.questionId == questionId }
+            
+            // TODO: Question 패치 필요
+            let question = Question(
+                id: questionId,
+                content: "테스트 질문 입니다.",
+                publishedDate: .init(),
+                isAnswered: false,
+                isLived: true
+            )
+            return (isAnswered, question)
         }
     )
     
@@ -77,7 +86,15 @@ extension NotificationRepository: DependencyKey {
             NotificationRepository.dummyBoard
         },
         isAnsweredQuestion: { _ in
-            false
+            let question = Question(
+                id: 1234,
+                content: "테스트 질문 입니다.",
+                publishedDate: .init(),
+                isAnswered: false,
+                isLived: true
+            )
+            
+            return (false, question)
         }
     )
 }

--- a/Qapple/Qapple/SourceCode/Data/Repository/NotificationRepository.swift
+++ b/Qapple/Qapple/SourceCode/Data/Repository/NotificationRepository.swift
@@ -62,19 +62,31 @@ extension NotificationRepository: DependencyKey {
             return response.result.toEntity
         },
         isAnsweredQuestion: { questionId in
-            let url = try QappleAPI.Answer.listOfProfile(threshold: nil, pageSize: 100).url()
-            let response: BaseResponse<AnswersOfProfileDTO> = try await NetworkService.shared.get(url: url)
-            let isAnswered = response.result.content.contains{ $0.questionId == questionId }
+            var hasNext = true
+            var threshold: String?
             
-            // TODO: Question 패치 필요
-            let question = Question(
-                id: questionId,
-                content: "테스트 질문 입니다.",
-                publishedDate: .init(),
-                isAnswered: false,
-                isLived: true
-            )
-            return (isAnswered, question)
+            while hasNext {
+                let url = try QappleAPI.Question.list(threshold: threshold, pageSize: 30).url()
+                let response: BaseResponse<QuestionsDTO> = try await NetworkService.shared.get(url: url)
+                
+                if let question = response.result.content.first(where: { $0.questionId == questionId }) {
+                    let entity = Question(
+                        id: question.questionId,
+                        content: question.content,
+                        publishedDate: question.livedAt?.ISO8601ToDate ?? .init(),
+                        isAnswered: question.isAnswered,
+                        isLived: question.questionStatus == "LIVE"
+                    )
+                    
+                    return (question.isAnswered, entity)
+                }
+                
+                hasNext = response.result.hasNext
+                threshold = response.result.threshold
+            }
+            
+            // id에 맞는 질문 찾기 실패시 에러 던지기
+            throw NSError()
         }
     )
     

--- a/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
@@ -109,6 +109,18 @@ struct MainFlowFeature {
                     state.path.append(.report(.init(dataType: dataType)))
                     return .none
                     
+                case let .element(id: _, action: .notificationList(.navigateToComment(board))):
+                    state.path.append(.comment(.init(board: board)))
+                    return .none
+                    
+                case let .element(id: _, action: .notificationList(.navigateToWriteAnswer(question))):
+                    state.path.append(.writeAnswer(.init(question: question)))
+                    return .none
+                    
+                case let .element(id: _, action: .notificationList(.navigateToAnswerList(question))):
+                    state.path.append(.answerList(.init(question: question)))
+                    return .none
+                    
                 case .element(id: _, action: .answerList(.backButtonTapped)):
                     state.path.removeAll()
                     return .none

--- a/Qapple/Qapple/SourceCode/Feature/6.Notification/NotificationFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/6.Notification/NotificationFeature.swift
@@ -28,7 +28,9 @@ struct NotificationFeature {
         case onRefresh
         case onPagenationCellAppear(Int)
         case notificationCellTapped(Int)
-        case reportedNotificationCellTapped
+        case reportedBoard
+        case unknownError
+        
         case backButtonTapped
         
         case fetchNotifications([QappleNotification], QappleAPI.PaginationInfo)
@@ -81,21 +83,29 @@ struct NotificationFeature {
                 return .run { [noti = state.notifications[index] ] send in
                     // 게시판 관련 알림일때
                     if let boardId = Int(noti.boardId) {
-                        let result = try await notificationRepository.fetchSingleBoard(boardId)
-                        
-                        // 신고된 게시물일 경우
-                        if result.isReported { await send(.reportedNotificationCellTapped) }
-                        else {
-                            await send(.navigateToComment(result))
+                        do {
+                            let result = try await notificationRepository.fetchSingleBoard(boardId)
+                            
+                            // 신고된 게시물일 경우
+                            if result.isReported { await send(.reportedBoard) }
+                            else {
+                                await send(.navigateToComment(result))
+                            }
+                        } catch {
+                            await send(.unknownError)
                         }
                     // 질문 관련 알림일때
                     } else if let questionId = Int(noti.id) {
-                        let result = try await notificationRepository.isAnsweredQuestion(questionId)
-                        
-                        if result.0 {
-                            await send(.navigateToAnswerList(result.1))
-                        } else {
-                            await send(.navigateToWriteAnswer(result.1))
+                        do {
+                            let result = try await notificationRepository.isAnsweredQuestion(questionId)
+                            
+                            if result.0 {
+                                await send(.navigateToAnswerList(result.1))
+                            } else {
+                                await send(.navigateToWriteAnswer(result.1))
+                            }
+                        } catch {
+                            await send(.unknownError)
                         }
                         
                     }
@@ -111,14 +121,13 @@ struct NotificationFeature {
                 state.isLoading = false
                 return .none
                 
-            case .reportedNotificationCellTapped:
-                state.alert = AlertState {
-                    TextState("신고된 게시글")
-                } actions: {
-                    ButtonState(role: .none, label: { TextState("확인") })
-                } message: {
-                    TextState("신고된 게시글은 열람할 수 없습니다.")
-                }
+            case .reportedBoard:
+                state.isLoading = false
+                state.alert = .reportedBoard
+                return .none
+            case .unknownError:
+                state.isLoading = false
+                state.alert = .unknownError
                 return .none
                 
             case .backButtonTapped:
@@ -131,5 +140,26 @@ struct NotificationFeature {
             }
         }
         .ifLet(\.alert, action: \.alert)
+    }
+}
+
+
+extension AlertState where Action == NotificationFeature.Action.Alert {
+    static let reportedBoard = Self {
+        TextState("신고된 게시글")
+    } actions: {
+        ButtonState(role: .none, label: { TextState("확인") })
+    } message: {
+        TextState("신고된 게시글은 열람할 수 없습니다.")
+    }
+    
+    static let unknownError = Self {
+        TextState("알 수 없는 오류가 발생했습니다.")
+    } actions: {
+        ButtonState(role: .cancel) {
+            TextState("확인")
+        }
+    } message: {
+        TextState("잠시후 다시 시도해주세요.")
     }
 }

--- a/Qapple/Qapple/SourceCode/Feature/6.Notification/NotificationFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/6.Notification/NotificationFeature.swift
@@ -32,7 +32,10 @@ struct NotificationFeature {
         case backButtonTapped
         
         case fetchNotifications([QappleNotification], QappleAPI.PaginationInfo)
-        case evaluateQuestion(Bool)
+        
+        case navigateToBulletinBoard(BulletinBoard)
+        case navigateToWriteAnswer(Question)
+        case navigateToAnswerList(Question)
         
         case alert(PresentationAction<Alert>)
         
@@ -74,6 +77,7 @@ struct NotificationFeature {
                 return .none
                 
             case let .notificationCellTapped(index):
+                state.isLoading = true
                 return .run { [noti = state.notifications[index] ] send in
                     // 게시판 관련 알림일때
                     if let boardId = Int(noti.boardId) {
@@ -82,20 +86,30 @@ struct NotificationFeature {
                         // 신고된 게시물일 경우
                         if result.isReported { await send(.reportedNotificationCellTapped) }
                         else {
-                            // TODO: 게시판으로 네비게이팅
+                            await send(.navigateToBulletinBoard(result))
                         }
                     // 질문 관련 알림일때
                     } else if let questionId = Int(noti.id) {
-                        // MARK: 현재 해당 질문의 답변 여부 파악을 위해 전체 질문을 뽑아서 찾음, 개선안 필요할듯
                         let result = try await notificationRepository.isAnsweredQuestion(questionId)
-                        await send(.evaluateQuestion(result))
+                        
+                        if result.0 {
+                            await send(.navigateToAnswerList(result.1))
+                        } else {
+                            await send(.navigateToWriteAnswer(result.1))
+                        }
+                        
                     }
                 }
                 
-            case .evaluateQuestion:
-                // TODO: 답변 여부에 따른 네비게이팅 필요
+            case .navigateToBulletinBoard:
+                state.isLoading = false
                 return .none
-                
+            case .navigateToWriteAnswer:
+                state.isLoading = false
+                return .none
+            case .navigateToAnswerList:
+                state.isLoading = false
+                return .none
                 
             case .reportedNotificationCellTapped:
                 state.alert = AlertState {

--- a/Qapple/Qapple/SourceCode/Feature/6.Notification/NotificationFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/6.Notification/NotificationFeature.swift
@@ -33,7 +33,7 @@ struct NotificationFeature {
         
         case fetchNotifications([QappleNotification], QappleAPI.PaginationInfo)
         
-        case navigateToBulletinBoard(BulletinBoard)
+        case navigateToComment(BulletinBoard)
         case navigateToWriteAnswer(Question)
         case navigateToAnswerList(Question)
         
@@ -86,7 +86,7 @@ struct NotificationFeature {
                         // 신고된 게시물일 경우
                         if result.isReported { await send(.reportedNotificationCellTapped) }
                         else {
-                            await send(.navigateToBulletinBoard(result))
+                            await send(.navigateToComment(result))
                         }
                     // 질문 관련 알림일때
                     } else if let questionId = Int(noti.id) {
@@ -101,7 +101,7 @@ struct NotificationFeature {
                     }
                 }
                 
-            case .navigateToBulletinBoard:
+            case .navigateToComment:
                 state.isLoading = false
                 return .none
             case .navigateToWriteAnswer:


### PR DESCRIPTION
close #292 

### TO-DO
- [x] NotificationFeature 수정(네비게이션 용 case 추가)
- [x] NotificationRepository 로직 수정(답변 여부 확인 로직 변경)
- [x] 네비게이션 연결(MainFlowFeature 수정)

### 상세 설명
- NotificationFeature 수정이 있습니다.(네비게이션 용 case 추가)
- NotificationRepository의 답변 여부 확인 로직을 변경했습니다. 기존에는 나의 답변에서 받아왔지만 그럴 경우 Question Entity를 넘기지 못하기 때문에 전체 질문을 뽑아 그 중에서 원하는 답변을 찾는 것으로 변경했습니다.
- QappleNotification의 조건에 맞는 뷰로 네비게이션을 진행할 수 있도록 수정했습니다.

### 스크린샷
질문 관련 notification은 없어 질문 관련 기능만 샘플 데이터를 넣어 작동 확인했습니다!

* 이미 답변한 질문 notification

https://github.com/user-attachments/assets/a73374b6-8a56-42ec-9ffe-7bc04ad684f1

* 답변하지 않은 질문 notification

https://github.com/user-attachments/assets/31610597-9390-4534-abe7-2bbd5c88b7f1

* 게시판 관련 notification

https://github.com/user-attachments/assets/488cad36-9a27-4ba2-8bcc-53cd73cc0540



