### PR TITLE
[FEAT] like 버튼 GA 활성화

### DIFF
--- a/Qapple/Qapple/SourceCode/Feature/3.BulletinBoard/3-1.BulletinBoard/BulletinBoardFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/3.BulletinBoard/3-1.BulletinBoard/BulletinBoardFeature.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Firebase
 import ComposableArchitecture
 
 @Reducer
@@ -102,6 +103,12 @@ struct BulletinBoardFeature {
                 return .none
                 
             case let .likeBoardButtonTapped(board):
+                let event = "likeBoardButtonTapped"
+                let parameters = [
+                    "itemName": "likeBoardButton",
+                    "itemCategory": "BulletinBoard"
+                ]
+                Analytics.logEvent(event, parameters: parameters)
                 HapticService.impact(style: .light)
                 return .run { send in
                     await send(.toggleLoading(true), animation: .bouncy)

--- a/Qapple/Qapple/SourceCode/Feature/3.BulletinBoard/3-1.BulletinBoard/BulletinBoardFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/3.BulletinBoard/3-1.BulletinBoard/BulletinBoardFeature.swift
@@ -105,8 +105,7 @@ struct BulletinBoardFeature {
             case let .likeBoardButtonTapped(board):
                 let event = "likeBoardButtonTapped"
                 let parameters = [
-                    "itemName": "likeBoardButton",
-                    "itemCategory": "BulletinBoard"
+                    "select_content": "likeBoardButton"
                 ]
                 Analytics.logEvent(event, parameters: parameters)
                 HapticService.impact(style: .light)

--- a/Qapple/Qapple/SourceCode/Feature/3.BulletinBoard/3-2.BulletinBoardPost/BulletinBoardPostFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/3.BulletinBoard/3-2.BulletinBoardPost/BulletinBoardPostFeature.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Firebase
 import ComposableArchitecture
 
 @Reducer
@@ -67,6 +68,11 @@ struct BulletinBoardPostFeature {
                 return .none
                 
             case .postBoardButtonTapped:
+                let event = "postBoardButtonTapped"
+                let parameters = [
+                    "select_content": "postBoardButton"
+                ]
+                Analytics.logEvent(event, parameters: parameters)
                 HapticService.notification(type: .success)
                 let boardText = state.boardText
                 return .run { send in


### PR DESCRIPTION
close #326

### TO-DO
- [x] GoogleAnalytics 적용

### 상세 설명
- GoogleAnalytics 적용 과정과 예시입니다

### 과정
이번에 Google Analytics를 알아보면서 공유하고 싶은 것입니다!

일단 Firebase 연동의 경우 AppDelegate에서
~~~
FirebaseApp.configure()
~~~
를 통해 Firebase 서비스를 사용할 수 있도록 준비하게 됩니다.(APNs 할 때 이미 적용되어있음)
이 코드를 통해 GoogleService-Info.plist를 읽어와서 설정 적용하고 앱 정보를 로드, 통신 준비하게됩니다.
(그래서 앱 실행할 때 가장 먼저 호출!)


다음으로 firebase 웹의 DebugView에서 실시간으로 이벤트를 확인하기 위해
![스크린샷 2025-02-27 오후 7 04 25](https://github.com/user-attachments/assets/679682d2-693e-4fcf-bafc-330a3647007e)
Scheme - Arguments에 '-FIRDebugEnabled'를 추가해줍니다.
기존 analytics는 데이터를 실시간으로 업로드하지 않고, 약 1시간 동안의 데이터를 모은 후에 한 번에 업로드하는 방식인데
Arguments를 추가해서 실시간으로 확인할 수 있도록 설정할 수 있습니다
(일단 제 계정으로 되어 있어서 웹에서 실시간 확인은 제 계정을 아는 사람만 확인할 수 있을 것 같아요..!)

그리고 아래 코드(게시글 좋아요 버튼)를 작성하고 실제 기기에서 작동을 하면
<img width="1124" alt="스크린샷 2025-02-27 오후 9 39 29" src="https://github.com/user-attachments/assets/bfc2f34d-b02d-4825-9d89-cc4cf661b7a3" />
이런식으로 log를 확인할 수 있습니다!

~~~
ga_debug (_dbg) = 1;
ga_event_origin (_o) = app;
ga_realtime (_r) = 1;
select_content = postBoardButton;
~~~
Xcode에서도 이렇게 찍히는데 아래와 같은 의미를 가지고 있습니다!
ga_debug (_dbg) = 1 → Debug 모드에서 이벤트 로깅
ga_event_origin (_o) = app → 이벤트가 앱에서 발생
ga_realtime (_r) = 1 → 실시간으로 처리

문제는 최근 30분밖에 볼 수 없어서(누적되는 데이터도 아닌듯함) 좀 더 알아봐야할 것 같아요!
하루가 지나야 볼 수 있는 건가싶기도하고..
일단 필요한 액션에만 적용하면 될 것 같아요!