### PR TITLE
[Feat] Github Actions을 사용한 CI 적용

### DIFF
--- a/.github/workflows/qappleCI.yml
+++ b/.github/workflows/qappleCI.yml
@@ -1,0 +1,42 @@
+name: Qapple CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - name: Set Xcode Version 🛠️
+      uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        # 16.2 버전 오류로 인해 16.1 버전 설정
+        xcode-version: "16.1"
+
+    - name: Check Xcode Version ✔
+      run: |
+        xcodebuild -version
+
+    - name: Checkout Repository 🖨️
+      uses: actions/checkout@v4
+
+    - name: Build 💻
+      run: |
+        xcodebuild clean build \
+        -project Qapple/Qapple.xcodeproj \
+        -scheme Qapple \
+        -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.1' \
+        -skipMacroValidation | xcpretty
+
+
+    

--- a/.github/workflows/qappleCI.yml
+++ b/.github/workflows/qappleCI.yml
@@ -11,10 +11,13 @@ on:
       - develop
 
 
-
 jobs:
   build:
     runs-on: macos-latest
+
+    #env: 
+    #  GOOGLE_SERVICE: ${{ secrets.GOOGLE_SERVICE }}
+    #  SERVER: ${{ secrets.SERVER }}
 
     steps:
     - name: Set Xcode Version 🛠️
@@ -29,6 +32,14 @@ jobs:
 
     - name: Checkout Repository 🖨️
       uses: actions/checkout@v4
+
+      
+    #- name: Make GoogleService-Info.plist
+    #  run: |
+    #    echo -n $GOOGLE_SERVICE | base64 --decode > Qapple/Qapple/QappleBox/GoogleService_Info.plist
+    #- name: Make Server.xcconfig
+    #  run: |
+    #    echo -n $SERVER | base64 --decode > Qapple/Qapple/QappleBox/Secrets.xcconfig
 
     - name: Build 💻
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ xcuserdata/
 ## Secrets
 Secrets.xcconfig
 GoogleService-Info.plist
-*.xcscheme
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint

--- a/Qapple/Qapple.xcodeproj/xcshareddata/xcschemes/Qapple.xcscheme
+++ b/Qapple/Qapple.xcodeproj/xcshareddata/xcschemes/Qapple.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F3EA66C72B7643EE002417CE"
+               BuildableName = "Qapple.app"
+               BlueprintName = "Qapple"
+               ReferencedContainer = "container:Qapple.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F3EA66C72B7643EE002417CE"
+            BuildableName = "Qapple.app"
+            BlueprintName = "Qapple"
+            ReferencedContainer = "container:Qapple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F3EA66C72B7643EE002417CE"
+            BuildableName = "Qapple.app"
+            BlueprintName = "Qapple"
+            ReferencedContainer = "container:Qapple.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
close #317 

### TO-DO
- [x] Github Actions 워크플로우 추가
- [x] Github Secrets 추가(네트워크, GA 관련)
- [x] gitignore 수정, scheme 추가

### 상세 설명
- Github Actions을 이용해 CI 기능을 추가했습니다.
- 현재 트리거는 [develop, main] 브랜치로 PR이 올라왔을 때, push 되었을 때 입니다.
- 구동 환경은 Xcode 16.1, iPhone 16 Pro, iOS 18.1 입니다.
- 프로젝트 빌드를 진행하며 빌드에서 문제가 있을 시 실패하게 됩니다.
- ~~gitignore에 있는 파일들은 Github secrets에 넣어 사용합니다.~~ -> 테스트를 넣지 못한 관계로 현재 사용하지는 않지만 추후에 추가할 예정입니다.

### 스크린샷
|기능|스크린샷|
|:--:|:--:|
|Actions|<img width="2014" alt="image" src="https://github.com/user-attachments/assets/5978c8b5-1970-4998-96d7-1cb5a8eac9c6" />|


