### PR TITLE
[Feat] 답변에 대한 댓글 뷰 추가

### DIFF
--- a/Qapple/Qapple/Resource/Constant/Constant.swift
+++ b/Qapple/Qapple/Resource/Constant/Constant.swift
@@ -17,5 +17,6 @@ enum Constant {
 
 extension Constant {
     static let isSignIn = "isSignIn"
+    static let recentQuestionID = "recentQuestionID"
     static let userRandomID = "userRandomID"
 }

--- a/Qapple/Qapple/SourceCode/App/AppDelegate.swift
+++ b/Qapple/Qapple/SourceCode/App/AppDelegate.swift
@@ -29,7 +29,7 @@ extension AppDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
         #if DEBUG
-        RepositoryService.shared.configureServer(to: .production)
+        RepositoryService.shared.configureServer(to: .test)
         #else
         RepositoryService.shared.configureServer(to: .production)
         #endif

--- a/Qapple/Qapple/SourceCode/Entity/AnswerComment.swift
+++ b/Qapple/Qapple/SourceCode/Entity/AnswerComment.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// MARK: 임시 Entity
 struct AnswerComment: Identifiable, Equatable {
     let id: Int
     let writeId: Int

--- a/Qapple/Qapple/SourceCode/Entity/AnswerComment.swift
+++ b/Qapple/Qapple/SourceCode/Entity/AnswerComment.swift
@@ -1,0 +1,22 @@
+//
+//  AnswerComment.swift
+//  Qapple
+//
+//  Created by 문인범 on 4/14/25.
+//
+
+import Foundation
+
+struct AnswerComment: Identifiable, Equatable {
+    let id: Int
+    let writeId: Int
+    let writerGeneration: String
+    let content: String
+    var heartCount: Int
+    var isLiked: Bool
+    let isMine: Bool
+    var isReport: Bool
+    let createdAt: Date
+    
+    var anonymityId: Int
+}

--- a/Qapple/Qapple/SourceCode/Entity/DataType.swift
+++ b/Qapple/Qapple/SourceCode/Entity/DataType.swift
@@ -12,4 +12,5 @@ enum DataType: Equatable {
     case answer(Answer)
     case bulletinBoard(BulletinBoard)
     case comment(BoardComment)
+    case answerComment(AnswerComment)
 }

--- a/Qapple/Qapple/SourceCode/Entity/QuestionState.swift
+++ b/Qapple/Qapple/SourceCode/Entity/QuestionState.swift
@@ -40,9 +40,9 @@ enum QuestionState: Codable {
     /// 질문 및 답변 여부에 따라 변화하는 버튼 문자열
     func buttonTitle(isAnswerd: Bool) -> String {
         switch self {
-        case .creating: isAnswerd ? "다른 답변 둘러보기" : "답변하기"
+        case .creating: isAnswerd ? "둘러보기" : "답변하기"
         case .ready: "답변하기"
-        case .complete: "다른 답변 둘러보기"
+        case .complete: "둘러보기"
         }
     }
 }

--- a/Qapple/Qapple/SourceCode/Entity/QuestionState.swift
+++ b/Qapple/Qapple/SourceCode/Entity/QuestionState.swift
@@ -40,8 +40,8 @@ enum QuestionState: Codable {
     /// 질문 및 답변 여부에 따라 변화하는 버튼 문자열
     func buttonTitle(isAnswerd: Bool) -> String {
         switch self {
-        case .creating: isAnswerd ? "다른 답변 둘러보기" : "이전 질문 답변하기"
-        case .ready: "질문에 답변하기"
+        case .creating: isAnswerd ? "다른 답변 둘러보기" : "답변하기"
+        case .ready: "답변하기"
         case .complete: "다른 답변 둘러보기"
         }
     }

--- a/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
@@ -74,6 +74,10 @@ struct MainFlowFeature {
                 state.path.append(.report(.init(dataType: dataType)))
                 return .none
                 
+            case let .questionTab(.todayQuestion((.answerCommentButtonTapped(answer)))):
+                state.path.append(.answerCommentList(.init(answer: answer)))
+                return .none
+                
             case let .bulletinBoardTab(.boardCellTapped(board)):
                 state.path.append(.comment(.init(board: board)))
                 return .none
@@ -207,6 +211,7 @@ extension MainFlowFeature {
         case writeAnswer(WriteAnswerFeature)
         case completeAnswer(CompleteAnswerFeature)
         case answerList(AnswerListFeature)
+        case answerCommentList(AnswerCommentFeature)
         case bulletinBoard(BulletinBoardFeature)
         case bulletinBoardSearch(BulletinBoardSearchFeature)
         case bulletinBoardPost(BulletinBoardPostFeature)

--- a/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
@@ -141,6 +141,10 @@ struct MainFlowFeature {
                     state.path.append(.report(.init(dataType: dataType)))
                     return .none
                     
+                case let .element(id: _, action: .answerList(.answerCommentButtonTapped(answer))):
+                    state.path.append(.answerCommentList(.init(answer: answer)))
+                    return .none
+                    
                 case let .element(id: _, action: .answerCommentList(.sheet(.presented(.seeMore(.reportButtonTapped(dataType)))))):
                     state.path.append(.report(.init(dataType: dataType)))
                     return .none

--- a/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowFeature.swift
@@ -141,6 +141,14 @@ struct MainFlowFeature {
                     state.path.append(.report(.init(dataType: dataType)))
                     return .none
                     
+                case let .element(id: _, action: .answerCommentList(.sheet(.presented(.seeMore(.reportButtonTapped(dataType)))))):
+                    state.path.append(.report(.init(dataType: dataType)))
+                    return .none
+                    
+                case let .element(id: _, action: .answerCommentList(.reportButtonTapped(answerComment))):
+                    state.path.append(.report(.init(dataType: .answerComment(answerComment))))
+                    return .none
+                    
                 case let .element(id: _, action: .bulletinBoardSearch(.sheet(.presented(.seeMore(.reportButtonTapped(dataType)))))):
                     state.path.append(.report(.init(dataType: dataType)))
                     return .none

--- a/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/1.MainFlow/MainFlowView.swift
@@ -48,6 +48,7 @@ struct MainFlowView: View {
             case let .writeAnswer(store): WriteAnswerView(store: store)
             case let .completeAnswer(store): CompleteAnswerView(store: store)
             case let .answerList(store): AnswerListView(store: store)
+            case let .answerCommentList(store): AnswerCommentView(store: store)
             case let .bulletinBoard(store): BulletinBoardView(store: store)
             case let .bulletinBoardSearch(store): BulletinBoardSearchView(store: store)
             case let .bulletinBoardPost(store): BulletinBoardPostView(store: store)

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionFeature.swift
@@ -19,8 +19,10 @@ struct TodayQuestionFeature {
         var timeRemainingForQuestion: TimeInterval = 0
         var isLoading = true
         var isFirstLaunch = true
+        var isNewQuestion = false
         @Presents var sheet: Sheet.State?
         @Presents var alert: AlertState<Action.Alert>?
+        @Shared(.appStorage(Constant.recentQuestionID)) var recentQuestionID = 0
     }
     
     enum Action {
@@ -79,6 +81,14 @@ struct TodayQuestionFeature {
             case let .mainQuestionResponse(mainQuestion):
                 state.isFirstLaunch = false
                 state.todayQuestion = mainQuestion
+                
+                if mainQuestion.id != state.recentQuestionID {
+                    state.isNewQuestion = true
+                    state.$recentQuestionID.withLock { $0 = mainQuestion.id }
+                } else {
+                    state.isNewQuestion = false
+                }
+                
                 if isQuestionLiveTime {
                     state.questionState = mainQuestion.isAnswered ? .complete : .ready
                     return .none

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionFeature.swift
@@ -36,6 +36,7 @@ struct TodayQuestionFeature {
         case questionButtonTapped(Question)
         case seeAllAnswerButtonTapped(Question)
         case seeMoreAnswerButtonTapped(Answer)
+        case answerCommentButtonTapped(Answer)
         case questionTimerTick
         case cancelQuestionTimer
         case toggleLoading(Bool)
@@ -140,6 +141,9 @@ struct TodayQuestionFeature {
                 
             case .cancelQuestionTimer:
                 return .cancel(id: CancelID.questionTimer)
+                
+            case .answerCommentButtonTapped:
+                return .none
                 
             case let .sheet(.presented(.seeMore(.alert(.presented(.confirmDeletion(sheetData)))))):
                 guard case let .answer(answer) = sheetData else { return .none }

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
@@ -13,13 +13,16 @@ struct TodayQuestionView: View {
     @Bindable var store: StoreOf<TodayQuestionFeature>
     
     var body: some View {
-        VStack(spacing: 0) {
-            HeaderView(store: store)
-            
-            ScrollView {
+        ScrollView {
+            VStack(spacing: 0) {
+                LargeHeaderView(store: store)
+                LargeQuestionButton(store: store)
+                // SmallHeaderView(store: store)
                 AnswerPreviewList(store: store)
             }
+            
         }
+        .background(.second)
         .scrollIndicators(.hidden)
         .onAppear {
             store.send(.onAppear)
@@ -40,37 +43,41 @@ struct TodayQuestionView: View {
     }
 }
 
-// MARK: - HeaderView
+// MARK: - SmallHeaderView
 
-private struct HeaderView: View {
+private struct SmallHeaderView: View {
     
     let store: StoreOf<TodayQuestionFeature>
     
     var body: some View {
-        HStack(spacing: 8) {
-            Image(store.questionState.graphicImage)
-                .resizable()
-                .scaledToFill()
-                .frame(width: 40, height: 40)
+        ZStack {
+            Color.first.ignoresSafeArea()
             
-            Text(store.questionState.mainTitle)
-                .font(.pretendard(.semiBold, size: 18))
-                .foregroundStyle(.wh)
-                .tracking(-1)
-            
-            Spacer()
-            
-            if store.questionState == .creating {
-                QuestionTimer()
-            } else {
-                AnsweringButton()
+            HStack(spacing: 8) {
+                Image(store.questionState.graphicImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 40, height: 40)
+                
+                Text(store.questionState.mainTitle)
+                    .font(.pretendard(.semiBold, size: 18))
+                    .foregroundStyle(.wh)
+                    .tracking(-1)
+                
+                Spacer()
+                
+                if store.questionState == .creating {
+                    QuestionTimer()
+                } else {
+                    AnsweringButton()
+                }
             }
+            .padding(.horizontal, 24)
+            .frame(maxWidth: .infinity)
+            .frame(height: 90)
+            .background(.second)
+            .cornerRadius(32, corners: [.bottomLeft, .bottomRight])
         }
-        .padding(.horizontal, 24)
-        .frame(maxWidth: .infinity)
-        .frame(height: 90)
-        .background(.second)
-        .cornerRadius(32, corners: [.bottomLeft, .bottomRight])
     }
     
     /// 질문 타이머
@@ -117,7 +124,9 @@ private struct HeaderView: View {
     }
 }
 
-private struct LegacyHeaderView: View {
+// MARK: - LargeHeaderView
+
+private struct LargeHeaderView: View {
     
     @State private var offsetY: CGFloat = 0
     
@@ -161,9 +170,9 @@ private struct LegacyHeaderView: View {
     }
 }
 
-// MARK: - QuestionButton
+// MARK: - LargeQuestionButton
 
-private struct QuestionButton: View {
+private struct LargeQuestionButton: View {
     
     let store: StoreOf<TodayQuestionFeature>
     
@@ -209,7 +218,6 @@ private struct QuestionButton: View {
         }
     }
 }
-
 // MARK: - AnswerPreviewList
 
 private struct AnswerPreviewList: View {

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
@@ -15,12 +15,14 @@ struct TodayQuestionView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                LargeHeaderView(store: store)
-                LargeQuestionButton(store: store)
-                // SmallHeaderView(store: store)
+                if store.isNewQuestion {
+                    LargeHeaderView(store: store)
+                    LargeQuestionButton(store: store)
+                } else {
+                    SmallHeaderView(store: store)
+                }
                 AnswerPreviewList(store: store)
             }
-            
         }
         .background(.second)
         .scrollIndicators(.hidden)

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
@@ -304,7 +304,7 @@ private struct AnswerPreviewList: View {
                         
                     },
                     commentAction: {
-                        
+                        store.send(.answerCommentButtonTapped(answer))
                     }
                 )
             }

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
@@ -13,18 +13,14 @@ struct TodayQuestionView: View {
     @Bindable var store: StoreOf<TodayQuestionFeature>
     
     var body: some View {
-        ZStack {
-            Color.second.ignoresSafeArea()
+        VStack(spacing: 0) {
+            HeaderView(store: store)
             
             ScrollView {
-                VStack(spacing: 0) {
-                    HeaderView(store: store)
-                    QuestionButton(store: store)
-                    AnswerPreviewList(store: store)
-                }
+                AnswerPreviewList(store: store)
             }
-            .scrollIndicators(.hidden)
         }
+        .scrollIndicators(.hidden)
         .onAppear {
             store.send(.onAppear)
         }
@@ -36,10 +32,7 @@ struct TodayQuestionView: View {
         }
         .loadingIndicator(isLoading: store.isLoading)
         .alert($store.scope(state: \.alert, action: \.alert))
-        .sheet(item: $store.scope(
-            state: \.sheet,
-            action: \.sheet)
-        ) { store in
+        .sheet(item: $store.scope(state: \.sheet, action: \.sheet)) { store in
             switch store.case {
             case let .seeMore(store): SeeMoreSheet(store: store)
             }
@@ -50,6 +43,81 @@ struct TodayQuestionView: View {
 // MARK: - HeaderView
 
 private struct HeaderView: View {
+    
+    let store: StoreOf<TodayQuestionFeature>
+    
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(store.questionState.graphicImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 40, height: 40)
+            
+            Text(store.questionState.mainTitle)
+                .font(.pretendard(.semiBold, size: 18))
+                .foregroundStyle(.wh)
+                .tracking(-1)
+            
+            Spacer()
+            
+            if store.questionState == .creating {
+                QuestionTimer()
+            } else {
+                AnsweringButton()
+            }
+        }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity)
+        .frame(height: 90)
+        .background(.second)
+        .cornerRadius(32, corners: [.bottomLeft, .bottomRight])
+    }
+    
+    /// 질문 타이머
+    private func QuestionTimer() -> some View {
+        Text(store.timeRemainingForQuestion.timerFormat)
+            .font(.pretendard(.bold, size: 22))
+            .foregroundStyle(LinearGradient.timer)
+            .monospacedDigit()
+            .kerning(-2)
+    }
+    
+    /// 답변하기 버튼
+    private func AnsweringButton() -> some View {
+        Button {
+            store.send(.questionButtonTapped(store.todayQuestion))
+        } label: {
+            Text(title)
+                .font(.pretendard(.semiBold, size: 15))
+                .frame(width: 84)
+                .padding(.vertical, 10)
+                .foregroundStyle(.main)
+                .background(backgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+        }
+        .opacity(store.isLoading ? 0 : 1)
+        .buttonStyle(ScalableButtonStyle())
+    }
+    
+    /// 버튼 제목
+    private var title: String {
+        store.questionState.buttonTitle(
+            isAnswerd: store.todayQuestion.isAnswered
+        )
+    }
+    
+    /// 버튼 배경 색상
+    private var backgroundColor: Color {
+        switch store.questionState {
+        case .creating:
+            store.todayQuestion.isAnswered ? .secondaryButton : .button
+        case .ready: .button
+        case .complete: .secondaryButton
+        }
+    }
+}
+
+private struct LegacyHeaderView: View {
     
     @State private var offsetY: CGFloat = 0
     
@@ -165,7 +233,7 @@ private struct AnswerPreviewList: View {
                 if store.answerPreviewList.isEmpty {
                     Spacer()
                     
-                    Text("아직 답변이 달리지않았어요\n첫 답변을 달아보세요!")
+                    Text("첫 답변을 달아보세요!")
                         .font(.pretendard(.semiBold, size: 14))
                         .foregroundStyle(.sub4)
                         .multilineTextAlignment(.center)

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-2.TodayQuestion/TodayQuestionView.swift
@@ -289,6 +289,12 @@ private struct AnswerPreviewList: View {
                     state: .normal,
                     seeMoreAction: {
                         store.send(.seeMoreAnswerButtonTapped(answer))
+                    },
+                    likeAction: {
+                        
+                    },
+                    commentAction: {
+                        
                     }
                 )
             }

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-6.AnswerList/AnswerListFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-6.AnswerList/AnswerListFeature.swift
@@ -33,6 +33,8 @@ struct AnswerListFeature {
         case networkingFailed(Error)
         case seeMoreAction(Answer)
         case backButtonTapped
+        case likeAnswerButtonTapped
+        case answerCommentButtonTapped(Answer)
         case toggleLoading(Bool)
         case sheet(PresentationAction<Sheet.Action>)
         case alert(PresentationAction<Alert>)
@@ -111,6 +113,13 @@ struct AnswerListFeature {
                 
             case .filterBlockedUser:
                 state.answerList = state.answerList.reversed().filter(UserDefaults.filterAnswerBlockedUser)
+                return .none
+                
+            case .likeAnswerButtonTapped:
+                // TODO: 좋아요 기능 구현 필요
+                return .none
+                
+            case .answerCommentButtonTapped:
                 return .none
                 
             case let .networkingFailed(error):

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-6.AnswerList/AnswerListView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-6.AnswerList/AnswerListView.swift
@@ -139,6 +139,12 @@ private struct AnswerList: View {
                         state: .normal,
                         seeMoreAction: {
                             store.send(.seeMoreAction(answer))
+                        },
+                        likeAction: {
+                            
+                        },
+                        commentAction: {
+                            
                         }
                     )
                     .configurePagination(

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-6.AnswerList/AnswerListView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-6.AnswerList/AnswerListView.swift
@@ -141,10 +141,10 @@ private struct AnswerList: View {
                             store.send(.seeMoreAction(answer))
                         },
                         likeAction: {
-                            
+                            store.send(.likeAnswerButtonTapped)
                         },
                         commentAction: {
-                            
+                            store.send(.answerCommentButtonTapped(answer))
                         }
                     )
                     .configurePagination(

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentCell.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentCell.swift
@@ -259,7 +259,7 @@ private struct CommentReportButton: View {
 
 
 #Preview {
-    let comment = BoardComment(
+    let comment = AnswerComment(
         id: 4,
         writeId: 5,
         writerGeneration: "3기",
@@ -272,10 +272,11 @@ private struct CommentReportButton: View {
         anonymityId: 2
     )
     
-    CommentCell(
+    AnswerCommentCell(
         comment: comment,
         like: {},
         delete: {},
-        report: {})
+        report: {}
+    )
 }
 

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentCell.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentCell.swift
@@ -1,0 +1,281 @@
+//
+//  AnswerCommentCell.swift
+//  Qapple
+//
+//  Created by 문인범 on 4/14/25.
+//
+
+import SwiftUI
+
+struct AnswerCommentCell: View {
+    let comment: AnswerComment
+    let like: () -> Void
+    let delete: () -> Void
+    let report: () -> Void
+    
+    @State private var hOffset: CGFloat = 0
+    @State private var reportedCommentVisible: Bool = false
+    
+    var body: some View {
+        ZStack {
+            if comment.isReport, !reportedCommentVisible {
+                ReportCell(reportedCommentVisible: $reportedCommentVisible)
+            } else {
+                HStack(spacing: 0) {
+                    Spacer()
+                        .frame(width: 73)
+                    
+                    CommentContentView(
+                        hOffset: $hOffset,
+                        reportedCommentVisible: $reportedCommentVisible,
+                        comment: comment,
+                        like: like
+                    )
+                    
+                    if comment.isMine {
+                        CommentDeleteButton(delete: delete)
+                    } else {
+                        CommentReportButton(report: report)
+                    }
+                }
+                .offset(x: hOffset)
+            }
+        }
+    }
+}
+
+
+// MARK: - ReportCell
+private struct ReportCell: View {
+    @Binding var reportedCommentVisible: Bool
+    
+    let screenWidth: CGFloat = UIScreen.main.bounds.width
+    
+    var body: some View {
+        HStack {
+            Text("신고에 의해 숨김처리 된 댓글입니다.")
+                .font(.pretendard(.semiBold, size: 14))
+                .foregroundStyle(.sub4)
+                .padding(.leading, 16)
+            
+            Spacer()
+            
+            Button {
+                reportedCommentVisible.toggle()
+            } label: {
+                Text("댓글 보기")
+                    .font(.pretendard(.medium, size: 14))
+                    .foregroundStyle(.text)
+            }
+            .padding(.trailing, 27)
+        }
+        .frame(width: screenWidth, height: 56.03)
+        .opacity(0.5)
+    }
+}
+
+
+// MARK: - ReportedCommentCell
+private struct CommentContentView: View {
+    @State private var anchor: CGFloat = 0
+    @State private var isCellToggled: Bool = false
+    
+    @Binding var hOffset: CGFloat
+    @Binding var reportedCommentVisible: Bool
+    
+    let comment: AnswerComment
+    let like: () -> Void
+    
+    let screenWidth: CGFloat = UIScreen.main.bounds.width
+    let anchorWidth: CGFloat = 73
+    
+    let publisher = NotificationCenter.default.publisher(for: .updateCommentCellToggle)
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 13) {
+            // 사용자 이미지
+            Image(.profileDummy)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28)
+                .padding(.top, 16)
+            
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 6) {
+                    // 사용자 이름
+                    if self.comment.anonymityId == -1 {
+                        Text("작성자")
+                            .font(.pretendard(.semiBold, size: 14))
+                            .foregroundStyle(.text)
+                    } else {
+                        Text("러너 \(self.comment.anonymityId)")
+                            .font(.pretendard(.semiBold, size: 14))
+                            .foregroundStyle(.icon)
+                    }
+                    
+                    Capsule()
+                        .frame(width: 32, height: 17)
+                        .foregroundStyle(.sub5)
+                        .overlay {
+                            Text(comment.writerGeneration.isEmpty ? "3기" : comment.writerGeneration)
+                                .font(.pretendard(.medium, size: 10))
+                                .foregroundStyle(.white)
+                        }
+                    
+                    // 댓글 timestamp
+                    Text(comment.createdAt.timeAgo)
+                        .font(.pretendard(.light, size: 12))
+                        .foregroundStyle(.disable)
+                }
+                
+                // 댓글 내용
+                Text(comment.content)
+                    .font(.pretendard(.medium, size: 14))
+                    .foregroundStyle(.main)
+            }
+            .padding(.vertical, 16)
+
+            
+            Spacer()
+            
+            
+            VStack {
+                // 댓글 좋아요 버튼
+                Button {
+                    if !comment.isReport {
+                        like()
+                    } else {
+                        reportedCommentVisible.toggle()
+                    }
+                } label: {
+                    if !comment.isReport {
+                        VStack {
+                            Image(systemName: comment.isLiked ? "heart.fill" : "heart")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 16)
+                                .foregroundStyle(comment.isLiked ? .button : .sub4)
+                            
+                            // 댓글 좋아요 갯수
+                            if comment.heartCount != 0 {
+                                Text("\(comment.heartCount)")
+                                    .font(.pretendard(.medium, size: 14))
+                                    .foregroundStyle(.sub3)
+                            }
+                        }
+                    } else {
+                        Text("댓글 숨기기")
+                            .font(.pretendard(.medium, size: 14))
+                            .foregroundStyle(.text)
+                    }
+                }
+            }
+            .padding(.top, 16)
+        }
+        .padding(.horizontal, 16)
+        .background(Color.bk)
+        .frame(width: screenWidth)
+        .gesture(drag, isEnabled: !comment.isReport)
+        .onReceive(publisher) { _ in
+            hOffset = 0
+            anchor = 0
+            isCellToggled = false
+        }
+    }
+    
+    private var drag: some Gesture {
+        DragGesture(minimumDistance: 50)
+            .onChanged { value in
+                withAnimation(.easeInOut) {
+                    let transWidth = value.translation.width
+                    
+                    hOffset = anchor + transWidth
+                    
+                    if anchor < 0 {
+                        isCellToggled = hOffset < -screenWidth / 3 + screenWidth / 15
+                    } else {
+                        isCellToggled = hOffset < -screenWidth / 15
+                    }
+                }
+            }
+            .onEnded { value in
+                withAnimation(.easeInOut) {
+                    if isCellToggled {
+                        anchor = -anchorWidth
+                    } else {
+                        anchor = 0
+                    }
+                    hOffset = anchor
+                }
+            }
+    }
+}
+
+// MARK: - CommentDeleteButton
+
+private struct CommentDeleteButton: View {
+    
+    let delete: () -> Void
+    
+    var body: some View {
+        Button {
+            delete()
+        } label: {
+            ZStack {
+                Color.delete
+                
+                Image(systemName: "trash")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 20)
+                    .foregroundStyle(Color.wh)
+            }
+        }
+        .frame(width: 73)
+    }
+}
+
+// MARK: - CommentReportButton
+
+private struct CommentReportButton: View {
+    
+    let report: () -> Void
+    
+    var body: some View {
+        Button {
+            report()
+        } label: {
+            ZStack {
+                Color.report
+                
+                Image(systemName: "light.beacon.min")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(Color.wh)
+            }
+        }
+        .frame(width: 73)
+    }
+}
+
+
+#Preview {
+    let comment = BoardComment(
+        id: 4,
+        writeId: 5,
+        writerGeneration: "3기",
+        content: "테스트입니다",
+        heartCount: 20,
+        isLiked: true,
+        isMine: false,
+        isReport: false,
+        createdAt: .now,
+        anonymityId: 2
+    )
+    
+    CommentCell(
+        comment: comment,
+        like: {},
+        delete: {},
+        report: {})
+}
+

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentFeature.swift
@@ -8,6 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
+// TODO: 4/14 - Reducer 업데이트 필요
 @Reducer
 struct AnswerCommentFeature {
     @ObservableState
@@ -28,7 +29,7 @@ struct AnswerCommentFeature {
         case pagination
         case commentListResponse([AnswerComment], QappleAPI.PaginationInfo)
         case paginationResponse([AnswerComment], QappleAPI.PaginationInfo)
-        case boardResponse(Answer)
+        case answerResponse(Answer)
         
         case backButtonTapped
         case likeCommentButtonTapped(AnswerComment)
@@ -39,8 +40,8 @@ struct AnswerCommentFeature {
         case deleteCommentButtonTapped(AnswerComment)
         case successDeletion
         
-        case likeBoardButtonTapped
-        case likeBoard
+        case likeAnswerButtonTapped
+        case likeAnswer
         case seeMoreAction
         case networkingFailed(Error)
         case toggleLoading(Bool)
@@ -55,8 +56,6 @@ struct AnswerCommentFeature {
         }
     }
     
-    @Dependency(\.commentRepository) var commentRepository
-    @Dependency(\.bulletinBoardRepository) var bulletinBoardRepository
     @Dependency(\.dismiss) var dismiss
     
     var body: some ReducerOf<Self> {
@@ -105,7 +104,7 @@ struct AnswerCommentFeature {
 //                state.paginationInfo = paginationInfo
                 return .none
                 
-            case let .boardResponse(answer):
+            case let .answerResponse(answer):
                 state.answer = answer
                 return .none
                 
@@ -114,10 +113,10 @@ struct AnswerCommentFeature {
                     await dismiss()
                 }
                 
-            case let .likeCommentButtonTapped(boardComment):
+            case let .likeCommentButtonTapped(answerComment):
                 HapticService.impact(style: .light)
                 return .run { [answer = state.answer] send in
-//                    await send(.toggleLoading(true), animation: .bouncy)
+                    await send(.toggleLoading(true), animation: .bouncy)
 //                    do {
 //                        try await commentRepository.likeBoardComment(boardComment.id)
 //                        await send(.likeComment(boardComment.id))
@@ -128,7 +127,7 @@ struct AnswerCommentFeature {
                     await send(.toggleLoading(false), animation: .bouncy)
                 }
                 
-            case let .likeComment(boardCommentId):
+            case let .likeComment(answerCommentId):
 //                if let index = state.commentList.firstIndex(where: { $0.id == boardCommentId }) {
 //                    state.commentList[index].isLiked.toggle()
 //                    state.commentList[index].heartCount += state.commentList[index].isLiked ? 1 : -1
@@ -171,7 +170,7 @@ struct AnswerCommentFeature {
                 NotificationCenter.default.post(name: .updateCommentCellToggle, object: nil)
                 return .send(.refresh)
                 
-            case .likeBoardButtonTapped:
+            case .likeAnswerButtonTapped:
                 HapticService.impact(style: .light)
                 return .run { [answer = state.answer] send in
                     await send(.toggleLoading(true), animation: .bouncy)
@@ -185,7 +184,7 @@ struct AnswerCommentFeature {
                     await send(.toggleLoading(false), animation: .bouncy)
                 }
                 
-            case .likeBoard:
+            case .likeAnswer:
 //                if state.answer.isLiked {
 //                    state.answer.heartCount -= 1
 //                } else {
@@ -195,12 +194,12 @@ struct AnswerCommentFeature {
                 return .none
                 
             case .seeMoreAction:
-//                state.sheet = .seeMore(
-//                    .init(
-//                        sheetTarget: state.board.isMine ? .mine : .others,
-//                        dataType: .bulletinBoard(state.board)
-//                    )
-//                )
+                state.sheet = .seeMore(
+                    .init(
+                        sheetTarget: state.answer.isMine ? .mine : .others,
+                        dataType: .answer(state.answer)
+                    )
+                )
                 return .none
                 
             case let .networkingFailed(error):
@@ -216,7 +215,7 @@ struct AnswerCommentFeature {
                 return .none
                 
             case let .sheet(.presented(.seeMore(.alert(.presented(.confirmDeletion(sheetData)))))):
-//                guard case let .bulletinBoard(board) = sheetData else { return .none }
+                guard case let .answer(answer) = sheetData else { return .none }
                 return .run { send in
                     await send(.toggleLoading(true), animation: .bouncy)
 //                    do {
@@ -239,23 +238,23 @@ struct AnswerCommentFeature {
                 return .none
                 
             case let .sheet(.presented(.seeMore(.alert(.presented(.confirmBlockUser(sheetData)))))):
-//                guard case let .bulletinBoard(board) = sheetData else { return .none }
+                guard case let .answer(answer) = sheetData else { return .none }
                 return .run { send in
-//                    UserDefaults.addBlockedUser(board.writerId)
-//                    await send(.sheet(.presented(.seeMore(.completionBlocking))))
+                    UserDefaults.addBlockedUser(answer.writerId)
+                    await send(.sheet(.presented(.seeMore(.completionBlocking))))
                 }
                 
             case .sheet(.presented(.seeMore(.alert(.presented(.confirmBlockCompletion))))):
                 state.sheet = nil
                 return .send(.onDisappear)
                 
-            case let .alert(.presented(.confirmDeletion(boardCommentId))):
+            case let .alert(.presented(.confirmDeletion(answerId))):
                 return .run { send in
                     await send(.toggleLoading(true), animation: .bouncy)
 //                    do {
 //                        try await commentRepository.deleteBoardComment(boardCommentId)
-//                        await send(.refresh)
-//                        await send(.successDeletion)
+                        await send(.refresh)
+                        await send(.successDeletion)
 //                    } catch {
 //                        await send(.networkingFailed(error))
 //                    }
@@ -283,14 +282,14 @@ extension AnswerCommentFeature {
 // MARK: - CommentAlert
 
 extension AlertState where Action == AnswerCommentFeature.Action.Alert {
-    static func confirmDeletion(_ boardCommentId: Int) -> Self {
+    static func confirmDeletion(_ answerCommentId: Int) -> Self {
         return Self {
             TextState("정말로 댓글을 삭제하시겠습니까?")
         } actions: {
             ButtonState(role: .cancel){
                 TextState("취소")
             }
-            ButtonState(role: .destructive, action: .confirmDeletion(boardCommentId)) {
+            ButtonState(role: .destructive, action: .confirmDeletion(answerCommentId)) {
                 TextState("삭제")
             }
         }
@@ -350,5 +349,40 @@ extension AnswerCommentFeature {
                 )
             }
         }
+    }
+}
+
+
+extension AnswerCommentFeature {
+    public static var sampleComment: [AnswerComment] {
+        var result = [AnswerComment]()
+        for i in 0..<10 {
+            result.append(.init(
+                id: i,
+                writeId: i,
+                writerGeneration: "4기",
+                content: "\(i)번째 댓글",
+                heartCount: i,
+                isLiked: false,
+                isMine: false,
+                isReport: false,
+                createdAt: .init(),
+                anonymityId: i
+            ))
+        }
+        
+        result.append(.init(
+            id: 10,
+            writeId: 10,
+            writerGeneration: "3기",
+            content: "하이용",
+            heartCount: 3,
+            isLiked: true,
+            isMine: true,
+            isReport: false,
+            createdAt: .init(),
+            anonymityId: -1
+        ))
+        return result
     }
 }

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentFeature.swift
@@ -1,0 +1,354 @@
+//
+//  AnswerCommentFeature.swift
+//  Qapple
+//
+//  Created by 문인범 on 4/14/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct AnswerCommentFeature {
+    @ObservableState
+    struct State: Equatable {
+        var answer: Answer
+        var commentText: String = ""
+        var commentList: [AnswerComment] = []
+        var paginationInfo = QappleAPI.PaginationInfo(threshold: "", hasNext: false)
+        var isLoading: Bool = false
+        @Presents var sheet: Sheet.State?
+        @Presents var alert: AlertState<Action.Alert>?
+    }
+    
+    enum Action: BindableAction {
+        case onAppear
+        case onDisappear
+        case refresh
+        case pagination
+        case commentListResponse([AnswerComment], QappleAPI.PaginationInfo)
+        case paginationResponse([AnswerComment], QappleAPI.PaginationInfo)
+        case boardResponse(Answer)
+        
+        case backButtonTapped
+        case likeCommentButtonTapped(AnswerComment)
+        case likeComment(Int)
+        case uploadCommentButtonTapped
+        case commentTextReset
+        case reportButtonTapped(AnswerComment)
+        case deleteCommentButtonTapped(AnswerComment)
+        case successDeletion
+        
+        case likeBoardButtonTapped
+        case likeBoard
+        case seeMoreAction
+        case networkingFailed(Error)
+        case toggleLoading(Bool)
+        case binding(BindingAction<State>)
+        
+        case sheet(PresentationAction<Sheet.Action>)
+        case alert(PresentationAction<Alert>)
+        
+        enum Alert: Equatable {
+            case confirmDeletion(Int)
+            case successDeletion
+        }
+    }
+    
+    @Dependency(\.commentRepository) var commentRepository
+    @Dependency(\.bulletinBoardRepository) var bulletinBoardRepository
+    @Dependency(\.dismiss) var dismiss
+    
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .onAppear, .refresh:
+                return .run { [answerId = state.answer.id] send in
+                    await send(.toggleLoading(true), animation: .bouncy)
+//                    do {
+//                        let commentResponse = try await commentRepository.fetchBoardCommentList(boardId, nil)
+//                        let boardResponse = try await bulletinBoardRepository.fetchSingleBoard(boardId)
+//                        await send(.commentListResponse(commentResponse.0, commentResponse.1))
+//                        await send(.boardResponse(boardResponse))
+//                    } catch {
+//                        await send(.networkingFailed(error))
+//                    }
+                    await send(.toggleLoading(false), animation: .bouncy)
+                }
+                
+            case .onDisappear:
+                return .none
+                
+            case .pagination:
+                return .run { [
+                    answerId = state.answer.id,
+                    threshold = Int(state.paginationInfo.threshold)
+                ] send in
+                    await send(.toggleLoading(true), animation: .bouncy)
+//                    do {
+//                        let response = try await commentRepository.fetchBoardCommentList(boardId, threshold)
+//                        await send(.paginationResponse(response.0, response.1))
+//                    } catch {
+//                        await send(.networkingFailed(error))
+//                    }
+                    await send(.toggleLoading(false), animation: .bouncy)
+                }
+                
+            case let .commentListResponse(commentList, paginationInfo):
+//                state.commentList = anonymizeCommentList(state.answer.writerId, commentList)
+//                state.paginationInfo = paginationInfo
+                return .none
+                
+            case let .paginationResponse(commentList, paginationInfo):
+//                state.commentList.append(contentsOf: anonymizeCommentList(state.answer.writerId, commentList))
+//                state.paginationInfo = paginationInfo
+                return .none
+                
+            case let .boardResponse(answer):
+                state.answer = answer
+                return .none
+                
+            case .backButtonTapped:
+                return .run { _ in
+                    await dismiss()
+                }
+                
+            case let .likeCommentButtonTapped(boardComment):
+                HapticService.impact(style: .light)
+                return .run { [answer = state.answer] send in
+//                    await send(.toggleLoading(true), animation: .bouncy)
+//                    do {
+//                        try await commentRepository.likeBoardComment(boardComment.id)
+//                        await send(.likeComment(boardComment.id))
+//                        GAService.log(.likeBoardComment(board: board, boardComment: boardComment))
+//                    } catch {
+//                        await send(.networkingFailed(error))
+//                    }
+                    await send(.toggleLoading(false), animation: .bouncy)
+                }
+                
+            case let .likeComment(boardCommentId):
+//                if let index = state.commentList.firstIndex(where: { $0.id == boardCommentId }) {
+//                    state.commentList[index].isLiked.toggle()
+//                    state.commentList[index].heartCount += state.commentList[index].isLiked ? 1 : -1
+//                }
+                return .none
+                
+            case .uploadCommentButtonTapped:
+                return .run { [
+                    text = state.commentText,
+                    answer = state.answer
+                ] send in
+                    await send(.toggleLoading(true), animation: .bouncy)
+//                    do {
+//                        try await commentRepository.postBoardComment(board.id, text)
+//                        HapticService.notification(type: .success)
+//                        GAService.log(.postBoardComment(board: board, comment: text))
+//                        await send(.refresh)
+//                        await send(.commentTextReset)
+//                    } catch {
+//                        await send(.networkingFailed(error))
+//                    }
+                    await send(.toggleLoading(false), animation: .bouncy)
+                }
+                
+            case .commentTextReset:
+                state.commentText = ""
+                return .none
+                
+            case .reportButtonTapped:
+                NotificationCenter.default.post(name: .updateCommentCellToggle, object: nil)
+                return .none
+                
+            case let .deleteCommentButtonTapped(boardComment):
+                HapticService.notification(type: .error)
+                state.alert = .confirmDeletion(boardComment.id)
+                return .none
+                
+            case .successDeletion:
+                state.alert = .successDeletion
+                NotificationCenter.default.post(name: .updateCommentCellToggle, object: nil)
+                return .send(.refresh)
+                
+            case .likeBoardButtonTapped:
+                HapticService.impact(style: .light)
+                return .run { [answer = state.answer] send in
+                    await send(.toggleLoading(true), animation: .bouncy)
+//                    do {
+//                        try await bulletinBoardRepository.likeBoard(answer.id)
+//                        await send(.likeBoard)
+//                        if !answer.isLiked { GAService.log(.likeBoardFromDetail(board: answer)) }
+//                    } catch {
+//                        await send(.networkingFailed(error))
+//                    }
+                    await send(.toggleLoading(false), animation: .bouncy)
+                }
+                
+            case .likeBoard:
+//                if state.answer.isLiked {
+//                    state.answer.heartCount -= 1
+//                } else {
+//                    state.answer.heartCount += 1
+//                }
+//                state.answer.isLiked.toggle()
+                return .none
+                
+            case .seeMoreAction:
+//                state.sheet = .seeMore(
+//                    .init(
+//                        sheetTarget: state.board.isMine ? .mine : .others,
+//                        dataType: .bulletinBoard(state.board)
+//                    )
+//                )
+                return .none
+                
+            case let .networkingFailed(error):
+                HapticService.notification(type: .error)
+                state.alert = .failedNetworking(with: error)
+                return .none
+                
+            case let .toggleLoading(bool):
+                state.isLoading = bool
+                return .none
+                
+            case .binding(\.commentText):
+                return .none
+                
+            case let .sheet(.presented(.seeMore(.alert(.presented(.confirmDeletion(sheetData)))))):
+//                guard case let .bulletinBoard(board) = sheetData else { return .none }
+                return .run { send in
+                    await send(.toggleLoading(true), animation: .bouncy)
+//                    do {
+//                        try await bulletinBoardRepository.deleteBoard(board.id)
+//                        await send(.sheet(.presented(.seeMore(.completionDeletion))))
+//                    } catch {
+//                        await send(.networkingFailed(error))
+//                    }
+                    await send(.toggleLoading(false), animation: .bouncy)
+                }
+                
+            case .sheet(.presented(.seeMore(.alert(.presented(.confirmCompletion))))):
+                state.sheet = nil
+                return .run { send in
+                    await send(.onDisappear)
+                }
+                
+            case .sheet(.presented(.seeMore(.reportButtonTapped))):
+                state.sheet = nil
+                return .none
+                
+            case let .sheet(.presented(.seeMore(.alert(.presented(.confirmBlockUser(sheetData)))))):
+//                guard case let .bulletinBoard(board) = sheetData else { return .none }
+                return .run { send in
+//                    UserDefaults.addBlockedUser(board.writerId)
+//                    await send(.sheet(.presented(.seeMore(.completionBlocking))))
+                }
+                
+            case .sheet(.presented(.seeMore(.alert(.presented(.confirmBlockCompletion))))):
+                state.sheet = nil
+                return .send(.onDisappear)
+                
+            case let .alert(.presented(.confirmDeletion(boardCommentId))):
+                return .run { send in
+                    await send(.toggleLoading(true), animation: .bouncy)
+//                    do {
+//                        try await commentRepository.deleteBoardComment(boardCommentId)
+//                        await send(.refresh)
+//                        await send(.successDeletion)
+//                    } catch {
+//                        await send(.networkingFailed(error))
+//                    }
+                    await send(.toggleLoading(false), animation: .bouncy)
+                }
+                
+            case .binding, .sheet, .alert:
+                return .none
+            }
+        }
+        .ifLet(\.$sheet, action: \.sheet)
+        .ifLet(\.$alert, action: \.alert)
+    }
+}
+
+// MARK: - BulletinBoardSheet
+
+extension AnswerCommentFeature {
+    @Reducer(state: .equatable)
+    enum Sheet {
+        case seeMore(SeeMoreSheetFeature)
+    }
+}
+
+// MARK: - CommentAlert
+
+extension AlertState where Action == AnswerCommentFeature.Action.Alert {
+    static func confirmDeletion(_ boardCommentId: Int) -> Self {
+        return Self {
+            TextState("정말로 댓글을 삭제하시겠습니까?")
+        } actions: {
+            ButtonState(role: .cancel){
+                TextState("취소")
+            }
+            ButtonState(role: .destructive, action: .confirmDeletion(boardCommentId)) {
+                TextState("삭제")
+            }
+        }
+    }
+    
+    static let successDeletion = Self {
+        TextState("댓글이 삭제되었습니다")
+    } actions: {
+        ButtonState(role: .cancel) {
+            TextState("확인")
+        }
+    }
+}
+
+extension AnswerCommentFeature {
+    // 이름을 익명화 해주는 method
+    private func anonymizeCommentList(_ BoardWriterId: Int, _ commentList: [AnswerComment]) -> [AnswerComment] {
+        var anonymousArray: [Int: Int] = [:]
+        var anonymousIndex: Int = 0
+        
+        return commentList.map { comment in
+            let isContainName = anonymousArray.values.contains { $0 == comment.writeId }
+            
+            if !isContainName {
+                anonymousIndex += 1
+                
+                let anonymityId = (comment.writeId == BoardWriterId) ? -1 : anonymousIndex
+                
+                anonymousArray.updateValue(comment.writeId, forKey: anonymityId)
+                
+                return AnswerComment(
+                    id: comment.id,
+                    writeId: comment.writeId,
+                    writerGeneration: "3기",
+                    content: comment.content,
+                    heartCount: comment.heartCount,
+                    isLiked: comment.isLiked,
+                    isMine: comment.isMine,
+                    isReport: comment.isReport,
+                    createdAt: comment.createdAt,
+                    anonymityId: (comment.writeId == BoardWriterId) ? -1 : anonymousIndex
+                )
+            } else {
+                let currentIndex = anonymousArray.first(where: { $0.value == comment.writeId })?.key ?? 0
+                
+                return AnswerComment(
+                    id: comment.id,
+                    writeId: currentIndex,
+                    writerGeneration: "3기",
+                    content: comment.content,
+                    heartCount: comment.heartCount,
+                    isLiked: comment.isLiked,
+                    isMine: comment.isMine,
+                    isReport: comment.isReport,
+                    createdAt: comment.createdAt,
+                    anonymityId: currentIndex
+                )
+            }
+        }
+    }
+}

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentView.swift
@@ -25,25 +25,28 @@ struct AnswerCommentView: View {
                 }
             )
             
-//            BulletinBoardCell(
-//                board: store.board,
-//                seeMore: {
-//                    store.send(.seeMoreAction)
-//                },
-//                like: {
-//                    store.send(.likeBoardButtonTapped)
-//                }
-//            )
-//            .frame(width: screenWidth)
-//            .disabled(store.isLoading)
+            QPAnswerCell(
+                answer: store.answer,
+                index: 0,
+                state: .normal,
+                seeMoreAction: {
+                    store.send(.seeMoreAction)
+                },
+                likeAction: {
+                    store.send(.likeAnswerButtonTapped)
+                },
+                commentAction: {}
+            )
+            .frame(width: screenWidth)
+            .disabled(store.isLoading)
             
-//            CommentListView(store: store)
-//            
-//            Spacer()
-//            
-//            AddCommentView(store: store)
-//                .frame(width: screenWidth)
-//                .padding(.bottom, 8)
+            CommentListView(store: store)
+            
+            Spacer()
+            
+            AddCommentView(store: store)
+                .frame(width: screenWidth)
+                .padding(.bottom, 8)
 
         }
         .background(Color.bk)
@@ -74,7 +77,7 @@ struct AnswerCommentView: View {
             .frame(height: 1)
     }
 }
-/*
+
 // MARK: - CommentListView
 
 private struct CommentListView: View {
@@ -85,9 +88,35 @@ private struct CommentListView: View {
             ScrollView {
                 LazyVStack(spacing: 0) {
                     seperator
+                    // TODO: 4/14 데이터 연결 필요
+//                    ForEach(Array(self.store.commentList.enumerated()), id: \.offset) { index, comment in
+//                        AnswerCommentCell(
+//                            comment: comment,
+//                            like: {
+//                                store.send(.likeCommentButtonTapped(comment))
+//                            },
+//                            delete: {
+//                                store.send(.deleteCommentButtonTapped(comment))
+//                            },
+//                            report: {
+//                                store.send(.reportButtonTapped(comment))
+//                            }
+//                        )
+//                        .configurePagination(
+//                            store.commentList,
+//                            currentIndex: index,
+//                            hasNext: store.paginationInfo.hasNext,
+//                            pagination: {
+//                                store.send(.pagination)
+//                            }
+//                        )
+//                        .disabled(store.isLoading)
+//                        
+//                        seperator
+//                    }
                     
-                    ForEach(Array(self.store.commentList.enumerated()), id: \.offset) { index, comment in
-                        CommentCell(
+                    ForEach(AnswerCommentFeature.sampleComment) { comment in
+                        AnswerCommentCell(
                             comment: comment,
                             like: {
                                 store.send(.likeCommentButtonTapped(comment))
@@ -99,15 +128,6 @@ private struct CommentListView: View {
                                 store.send(.reportButtonTapped(comment))
                             }
                         )
-                        .configurePagination(
-                            store.commentList,
-                            currentIndex: index,
-                            hasNext: store.paginationInfo.hasNext,
-                            pagination: {
-                                store.send(.pagination)
-                            }
-                        )
-                        .disabled(store.isLoading)
                         
                         seperator
                     }
@@ -116,17 +136,17 @@ private struct CommentListView: View {
             .scrollDismissesKeyboard(.immediately)
             .background(Color.bk)
             
-            if store.commentList.isEmpty && !store.isLoading {
-                VStack {
-                    Text("아직 작성된 댓글이 없습니다")
-                        .font(.pretendard(.medium, size: 14))
-                        .foregroundStyle(.sub5)
-                        .multilineTextAlignment(.center)
-                        .padding(.top, 24)
-                    
-                    Spacer()
-                }
-            }
+//            if store.commentList.isEmpty && !store.isLoading {
+//                VStack {
+//                    Text("아직 작성된 댓글이 없습니다")
+//                        .font(.pretendard(.medium, size: 14))
+//                        .foregroundStyle(.sub5)
+//                        .multilineTextAlignment(.center)
+//                        .padding(.top, 24)
+//                    
+//                    Spacer()
+//                }
+//            }
         }
     }
     
@@ -172,26 +192,23 @@ private struct AddCommentView: View {
 
 // MARK: - Preview
 
-//#Preview {
-//    CommentView(
-//        store: Store(
-//            initialState: AnswerCommentFeature.State(
-//                board: BulletinBoard(
-//                    id: 1,
-//                    writerId: 1,
-//                    writerNickname: "이호창",
-//                    writerGeneration: "3기",
-//                    content: "특전사",
-//                    heartCount: 10,
-//                    commentCount: 13,
-//                    createAt: .init(),
-//                    isMine: false,
-//                    isReported: false,
-//                    isLiked: true
-//                )
-//            )
-//        ){
-//        CommentFeature()
-//    })
-//}
-*/
+#Preview {
+    AnswerCommentView(
+        store: Store(
+            initialState: AnswerCommentFeature.State(
+                answer: Answer(
+                    id: 1,
+                    writerId: 1,
+                    content: "특전사",
+                    authorNickname: "이호창",
+                    authorGeneration: "3기",
+                    publishedDate: .init(),
+                    isReported: false,
+                    isMine: false,
+                    isResignMember: false
+                )
+            )
+        ){
+        AnswerCommentFeature()
+    })
+}

--- a/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/2.QuestionTab/2-7.AnswerCommentList/AnswerCommentView.swift
@@ -1,0 +1,197 @@
+//
+//  AnswerCommentView.swift
+//  Qapple
+//
+//  Created by 문인범 on 4/14/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct AnswerCommentView: View {
+    @Bindable var store: StoreOf<AnswerCommentFeature>
+    
+    private let screenWidth: CGFloat = UIScreen.main.bounds.width
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            QPNavigationBar(
+                title: "댓글",
+                backgroundColor: Background.first,
+                leadingView: {
+                    QPNavigationButton(buttonType: .back) {
+                        store.send(.backButtonTapped)
+                    }
+                }
+            )
+            
+//            BulletinBoardCell(
+//                board: store.board,
+//                seeMore: {
+//                    store.send(.seeMoreAction)
+//                },
+//                like: {
+//                    store.send(.likeBoardButtonTapped)
+//                }
+//            )
+//            .frame(width: screenWidth)
+//            .disabled(store.isLoading)
+            
+//            CommentListView(store: store)
+//            
+//            Spacer()
+//            
+//            AddCommentView(store: store)
+//                .frame(width: screenWidth)
+//                .padding(.bottom, 8)
+
+        }
+        .background(Color.bk)
+        .onTapGesture {
+            hideKeyboard()
+        }
+        .navigationBarBackButtonHidden()
+        .popGestureEnabled(true)
+        .onAppear {
+            store.send(.onAppear)
+        }
+        .refreshable {
+            store.send(.refresh)
+        }
+        .loadingIndicator(isLoading: store.isLoading)
+        .sheet(item: $store.scope(state: \.sheet, action: \.sheet)
+        ) { store in
+            switch store.case {
+            case let .seeMore(store): SeeMoreSheet(store: store)
+            }
+        }
+        .alert($store.scope(state: \.alert, action: \.alert))
+    }
+    
+    private var seperator: some View {
+        Rectangle()
+            .foregroundStyle(Color.placeholder)
+            .frame(height: 1)
+    }
+}
+/*
+// MARK: - CommentListView
+
+private struct CommentListView: View {
+    let store: StoreOf<AnswerCommentFeature>
+    
+    var body: some View {
+        ZStack {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    seperator
+                    
+                    ForEach(Array(self.store.commentList.enumerated()), id: \.offset) { index, comment in
+                        CommentCell(
+                            comment: comment,
+                            like: {
+                                store.send(.likeCommentButtonTapped(comment))
+                            },
+                            delete: {
+                                store.send(.deleteCommentButtonTapped(comment))
+                            },
+                            report: {
+                                store.send(.reportButtonTapped(comment))
+                            }
+                        )
+                        .configurePagination(
+                            store.commentList,
+                            currentIndex: index,
+                            hasNext: store.paginationInfo.hasNext,
+                            pagination: {
+                                store.send(.pagination)
+                            }
+                        )
+                        .disabled(store.isLoading)
+                        
+                        seperator
+                    }
+                }
+            }
+            .scrollDismissesKeyboard(.immediately)
+            .background(Color.bk)
+            
+            if store.commentList.isEmpty && !store.isLoading {
+                VStack {
+                    Text("아직 작성된 댓글이 없습니다")
+                        .font(.pretendard(.medium, size: 14))
+                        .foregroundStyle(.sub5)
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 24)
+                    
+                    Spacer()
+                }
+            }
+        }
+    }
+    
+    private var seperator: some View {
+        Rectangle()
+            .frame(height: 1)
+            .foregroundStyle(Color.placeholder)
+    }
+}
+
+// MARK: - AddCommentView
+
+private struct AddCommentView: View {
+    @Bindable var store: StoreOf<AnswerCommentFeature>
+    
+    var body: some View {
+        HStack(alignment: .bottom) {
+            TextField("댓글 추가", text: $store.commentText, axis: .vertical)
+                .font(.pretendard(.regular, size: 17))
+                .lineLimit(...3)
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+            
+            Button {
+                store.send(.uploadCommentButtonTapped)
+            } label: {
+                Image(systemName: "paperplane")
+                    .font(.system(size: 20))
+            }
+            .tint(Color.wh)
+            .padding(.trailing, 12)
+            .padding(.bottom, 12)
+            .disabled(store.commentText.isEmpty || store.isLoading )
+        }
+        .background {
+            RoundedRectangle(cornerRadius: 11)
+                .foregroundStyle(Color.placeholder)
+        }
+        .frame(minHeight: 50)
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Preview
+
+//#Preview {
+//    CommentView(
+//        store: Store(
+//            initialState: AnswerCommentFeature.State(
+//                board: BulletinBoard(
+//                    id: 1,
+//                    writerId: 1,
+//                    writerNickname: "이호창",
+//                    writerGeneration: "3기",
+//                    content: "특전사",
+//                    heartCount: 10,
+//                    commentCount: 13,
+//                    createAt: .init(),
+//                    isMine: false,
+//                    isReported: false,
+//                    isLiked: true
+//                )
+//            )
+//        ){
+//        CommentFeature()
+//    })
+//}
+*/

--- a/Qapple/Qapple/SourceCode/Feature/5.Profile/5-3.MyAnswerList/MyAnswerListView.swift
+++ b/Qapple/Qapple/SourceCode/Feature/5.Profile/5-3.MyAnswerList/MyAnswerListView.swift
@@ -70,6 +70,12 @@ private struct MyAnswerList: View {
                             state: .written,
                             seeMoreAction:{
                                 store.send(.seeMoreAction(answer))
+                            },
+                            likeAction: {
+                                
+                            },
+                            commentAction: {
+                                
                             }
                         )
                         .configurePagination(

--- a/Qapple/Qapple/SourceCode/Feature/7.SeeMoreSheet/SeeMoreSheetFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/7.SeeMoreSheet/SeeMoreSheetFeature.swift
@@ -90,7 +90,7 @@ extension AlertState where Action == SeeMoreSheetFeature.Action.Alert {
         let targetText = switch dataType {
         case .answer: "답변"
         case .bulletinBoard: "게시글"
-        case .comment: "댓글"
+        case .comment, .answerComment: "댓글"
         }
         return Self {
             TextState("\(targetText)을 삭제하시겠어요?")
@@ -111,7 +111,7 @@ extension AlertState where Action == SeeMoreSheetFeature.Action.Alert {
         let targetText = switch dataType {
         case .answer: "답변"
         case .bulletinBoard: "게시글"
-        case .comment: "댓글"
+        case .comment, .answerComment: "댓글"
         }
         return Self {
             TextState("\(targetText)이 삭제되었어요")
@@ -127,7 +127,7 @@ extension AlertState where Action == SeeMoreSheetFeature.Action.Alert {
         let targetText = switch dataType {
         case .answer: "답변"
         case .bulletinBoard: "게시글"
-        case .comment: "댓글"
+        case .comment, .answerComment: "댓글"
         }
         return Self {
             TextState("\(targetText) 사용자를 차단하시겠어요?")
@@ -148,7 +148,7 @@ extension AlertState where Action == SeeMoreSheetFeature.Action.Alert {
         let targetText = switch dataType {
         case .answer: "답변"
         case .bulletinBoard: "게시글"
-        case .comment: "댓글"
+        case .comment, .answerComment: "댓글"
         }
         return Self {
             TextState("\(targetText) 사용자가 차단되었어요")

--- a/Qapple/Qapple/SourceCode/Feature/8.Report/ReportFeature.swift
+++ b/Qapple/Qapple/SourceCode/Feature/8.Report/ReportFeature.swift
@@ -59,6 +59,9 @@ struct ReportFeature {
                             
                         case let .comment(comment):
                             try await reportRepository.reportComment(comment.id, reportType)
+                        case let .answerComment(comment):
+                            // TODO: 답면 댓글 신고 구현
+                            break
                             
                         }
                         await send(.completionReport)
@@ -98,7 +101,7 @@ extension AlertState where Action == ReportFeature.Action.Alert {
         let targetText = switch dataType {
         case .answer: "답변"
         case .bulletinBoard: "게시글"
-        case .comment: "댓글"
+        case .comment, .answerComment: "댓글"
         }
         return Self {
             TextState("\(targetText)을 신고하시겠어요?")
@@ -117,7 +120,7 @@ extension AlertState where Action == ReportFeature.Action.Alert {
         let targetText = switch dataType {
         case .answer: "답변"
         case .bulletinBoard: "게시글"
-        case .comment: "댓글"
+        case .comment, .answerComment: "댓글"
         }
         return Self {
             TextState("\(targetText)이 신고되었어요")

--- a/Qapple/Qapple/SourceCode/UIComponent/QPAnswerCell.swift
+++ b/Qapple/Qapple/SourceCode/UIComponent/QPAnswerCell.swift
@@ -18,6 +18,8 @@ struct QPAnswerCell: View {
     let index: Int
     let state: State
     let seeMoreAction: () -> Void
+    let likeAction: () -> Void
+    let commentAction: () -> Void
     
     var body: some View {
         switch state {
@@ -33,7 +35,9 @@ struct QPAnswerCell: View {
                     answer: answer,
                     index: index,
                     author: author(index: index),
-                    seeMoreAction: seeMoreAction
+                    seeMoreAction: seeMoreAction,
+                    likeAction: likeAction,
+                    commentAction: commentAction
                 )
             }
             
@@ -42,7 +46,9 @@ struct QPAnswerCell: View {
                 answer: answer,
                 index: index,
                 author: answer.authorNickname,
-                seeMoreAction: seeMoreAction
+                seeMoreAction: seeMoreAction,
+                likeAction: likeAction,
+                commentAction: commentAction
             )
         }
     }
@@ -62,6 +68,8 @@ private struct NormalCell: View {
     let index: Int
     let author: String
     let seeMoreAction: () -> Void
+    let likeAction: () -> Void
+    let commentAction: () -> Void
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -70,11 +78,16 @@ private struct NormalCell: View {
             }
             
             Header()
-                .padding(.top, 18)
+                .padding(.top, 20)
                 .padding(.horizontal, 16)
             
             Content()
-                .padding(.bottom, 16)
+                .padding(.top, 8)
+                .padding(.horizontal, 16)
+            
+            Footer()
+                .padding(.top, 8)
+                .padding(.bottom, 20)
                 .padding(.horizontal, 16)
         }
         .background(.first)
@@ -129,6 +142,44 @@ private struct NormalCell: View {
                 .pretendard(.medium, 16)
                 .foregroundStyle(.main)
                 .padding(.top, 2)
+        }
+    }
+    
+    private func Footer() -> some View {
+        HStack(spacing: 0) {
+            Circle()
+                .foregroundStyle(.clear)
+                .frame(width: 28, height: 28)
+            
+            Button {
+                likeAction()
+            } label: {
+                HStack(spacing: 4) {
+                    Image(true ? .heartActive : .heart)
+                        .resizable()
+                        .frame(width: 18, height: 18)
+                    
+                    Text("32")
+                        .pretendard(.regular, 13)
+                        .foregroundStyle(.sub3)
+                }
+            }
+            .padding(.leading, 8)
+            
+            Button {
+                commentAction()
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "text.bubble.fill")
+                        .resizable()
+                        .frame(width: 15, height: 14)
+                    
+                    Text("32")
+                        .pretendard(.regular, 13)
+                }
+                .foregroundStyle(.sub3)
+            }
+            .padding(.leading, 12)
         }
     }
 }
@@ -303,11 +354,46 @@ private struct ReportedCell: View {
         Color.first.ignoresSafeArea()
         
         VStack(alignment: .leading, spacing: 0) {
-            QPAnswerCell(answer: answers[0], index: 0, state: .normal) {}
-            QPAnswerCell(answer: answers[1], index: 1, state: .normal) {}
-            QPAnswerCell(answer: answers[2], index: 2, state: .normal) {}
-            QPAnswerCell(answer: answers[3], index: 3, state: .normal) {}
-            QPAnswerCell(answer: answers[1], index: 4, state: .written) {}
+            QPAnswerCell(
+                answer: answers[0],
+                index: 0,
+                state: .normal,
+                seeMoreAction: {},
+                likeAction: {},
+                commentAction: {}
+            )
+            QPAnswerCell(
+                answer: answers[1],
+                index: 1,
+                state: .normal,
+                seeMoreAction: {},
+                likeAction: {},
+                commentAction: {}
+            )
+            QPAnswerCell(
+                answer: answers[2],
+                index: 2,
+                state: .normal,
+                seeMoreAction: {},
+                likeAction: {},
+                commentAction: {}
+            )
+            QPAnswerCell(
+                answer: answers[3],
+                index: 3,
+                state: .normal,
+                seeMoreAction: {},
+                likeAction: {},
+                commentAction: {}
+            )
+            QPAnswerCell(
+                answer: answers[1],
+                index: 4,
+                state: .written,
+                seeMoreAction: {},
+                likeAction: {},
+                commentAction: {}
+            )
         }
     }
 }

--- a/Qapple/Qapple/SourceCode/UIComponent/QPAnswerCell.swift
+++ b/Qapple/Qapple/SourceCode/UIComponent/QPAnswerCell.swift
@@ -86,7 +86,7 @@ private struct NormalCell: View {
                 .padding(.horizontal, 16)
             
             Footer()
-                .padding(.top, 8)
+                .padding(.top, 6)
                 .padding(.bottom, 20)
                 .padding(.horizontal, 16)
         }


### PR DESCRIPTION
close #360 

### TO-DO
- [x] 답변에 대한 댓글 뷰 추가

### 상세 설명
- 답변에 대한 댓글 뷰, 댓글 셀, 댓글 Reducer 추가(기존 뷰와 Reducer 재활용)
- 완전 재활용 해서 뷰는 완전 똑같습니다.
- 달라진건 내부의 BulletinBoard를 받는 프로퍼티와 프로퍼티 명칭을 answer로 변경했습니다.
- 아직 API 업데이트 전이라 일단 뷰만 구현해놓고 API 업데이트 후 기능 연결을 진행하겠습니다.

### 스크린샷
|기능|스크린샷|
|:--:|:--:|
|답변에 대한 댓글 뷰|<img width="492" alt="스크린샷 2025-04-14 오후 8 17 52" src="https://github.com/user-attachments/assets/b58a5f2e-95b2-48f6-aaa6-703e7238313d" />|

